### PR TITLE
Prevent automatic PhantomJS install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in govuk_admin_template.gemspec
 gemspec
+
+gem 'jasmine', :git => "git://github.com/fofr/jasmine-gem.git", :branch => "preventable-phantomjs-install"

--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bootstrap-sass', '3.1.0'
   gem.add_dependency 'jquery-rails', '3.0.4'
 
+  # There are some further development dependencies in the gemfile
   gem.add_development_dependency 'rails', '3.2.18'
   gem.add_development_dependency 'sass-rails', '3.2.6'
   gem.add_development_dependency 'rspec-rails', '2.14.2'
-  gem.add_development_dependency 'jasmine', '2.0.0'
   gem.add_development_dependency 'capybara', '2.2.1'
 end

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,11 +1,5 @@
 #Use this file to set/override Jasmine configuration options
-#You can remove it if you don't need it.
 #This file is loaded *after* jasmine.yml is interpreted.
-#
-#Example: using a different boot file.
-#Jasmine.configure do |config|
-#   config.boot_dir = '/absolute/path/to/boot_dir'
-#   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
-#end
-#
-
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+end


### PR DESCRIPTION
- Use forked gem with phantomjs config added to prevent insecure automatic downloads
- Temporarily use a forked version of jasmine-gem
  - PR outstanding: https://github.com/pivotal/jasmine-gem/pull/213
