### PR TITLE
Put gem templates through parent's app controller

### DIFF
--- a/app/controllers/govuk_admin_template/application_controller.rb
+++ b/app/controllers/govuk_admin_template/application_controller.rb
@@ -1,0 +1,2 @@
+class GovukAdminTemplate::ApplicationController < ApplicationController
+end


### PR DESCRIPTION
- The style guide template should render through the parent app’s
  application controller and template — eg showing the parent’s
  application name, main navigation and so on.
- Following guide from
  http://guides.rubyonrails.org/engines.html#using-a-controller-provided-b
  y-the-application
- Prior to this the style guide route was not working in app’s using
  the gem because GovukAdminTemplate::ApplicationController wasn’t
  available
