### PR TITLE
Fix gem.files to include all needed files.

### DIFF
--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = gem.description
   gem.homepage      = "https://github.com/alphagov/govuk_admin_template"
 
-  gem.files         = Dir["{app,lib}/**/*"] + ["LICENCE.txt", "README.md"]
+  gem.files         = Dir["{app,config,lib}/**/*"] + Dir["*.md"] + ["LICENCE.txt"]
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'rails', '>= 3.2.0'


### PR DESCRIPTION
This wasn't including `config/routes.rb` which led to failures using the
gem that didn't happen when using the checkout.

Also included some of the other documentation files in the root.
