### PR TITLE
Add GOV.UK user friendly date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This gem provides (via a Rails engine):
 * A [lightweight javascript framework](JAVASCRIPT.md)
 * Admin design patterns available from `/style-guide` (when routes are mounted)
 * SASS variables for the admin theme
+* GOV.UK user friendly date formats
 
 ## Usage
 
@@ -64,6 +65,18 @@ Example navbar_items:
     <a href="#">navbar_item</a>
   </li>
 <% end %>
+```
+
+### Date formats
+
+The [gem includes](lib/govuk_admin_template/engine.rb) `:govuk_date` date and time formats which match the [recommended style](https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times).
+
+```ruby
+# 1 January 2013
+date.to_s(:govuk_date)
+
+# 1:15pm, 1 January 2013
+time.to_s(:govuk_date)
 ```
 
 ## Development

--- a/lib/govuk_admin_template/engine.rb
+++ b/lib/govuk_admin_template/engine.rb
@@ -6,5 +6,15 @@ module GovukAdminTemplate
     initializer 'govuk_admin_template.assets.precompile' do |app|
       app.config.assets.precompile += %w(lte-ie8.js govuk-admin-template.js)
     end
+
+    # User friendly GOV.UK date formats, based on:
+    # https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times
+    initializer 'govuk_admin_template.date_formats' do |app|
+      # 1 January 2013
+      Date::DATE_FORMATS[:govuk_date] = '%-e %B %Y'
+
+      # 1:15pm, 1 January 2013
+      Time::DATE_FORMATS[:govuk_date] = '%-I:%M%P, %-e %B %Y'
+    end
   end
 end


### PR DESCRIPTION
- Add `:govuk_date` to date and time `DATE_FORMATS` for easy use within
  applications
- Ported from Transition en.yml localisation
