### PR TITLE
Fix visited link styles on bootstrap components

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/base.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/base.css.scss
@@ -196,6 +196,60 @@ main a {
 
 }
 
+/* Visited links in Bootstrap component overrides
+   ========================================================================== */
+
+/* Navigation pills */
+
+.nav-pills a:visited {
+  color: $link-color;
+}
+
+.nav-pills a:visited:hover {
+  color: $link-hover-color;
+}
+
+/* Dropdown menu */
+
+.dropdown-menu a:visited {
+  color: $text-color;
+}
+
+/* List groups */
+
+.list-group a.list-group-item:visited {
+  color: $list-group-link-color;
+}
+
+.list-group a.list-group-item:visited:hover {
+  color: $list-group-link-color;
+}
+
+.list-group a.list-group-item.active:visited {
+  color: $list-group-active-text-color;
+}
+
+.list-group a.list-group-item.active:visited:hover {
+  color: $list-group-active-text-color;
+}
+
+/* List groups with content  */
+
+a.list-group-item {
+
+  &:hover .list-group-item-heading {
+    text-decoration: underline;
+  }
+
+  .list-group-item-heading {
+    color: $link-color;
+  }
+
+}
+
+/* Further link types
+   ========================================================================== */
+
 .link-muted,
 .link-muted:visited {
   color: $gray-light;
@@ -207,14 +261,8 @@ main a {
   color: $gray;
 }
 
-// Force long URLs to break
-.breakable {
-  word-break: break-all;
-  display: inline-block;
-}
-
-.glossary-link,
-.glossary-link:visited {
+.link-inherit,
+.link-inherit:visited {
   color: inherit;
   text-decoration: underline;
 }
@@ -255,6 +303,12 @@ main a {
    Common content patterns
    ========================================================================== */
 
+// Force long URLs to break
+.breakable {
+  word-break: break-all;
+  display: inline-block;
+}
+
 .subtitle {
   margin: -$default-vertical-margin 0 $default-vertical-margin;
   font-size: $font-size-large;
@@ -273,18 +327,6 @@ main a {
 .list-group-item {
   padding-top:    $default-vertical-margin;
   padding-bottom: $default-vertical-margin;
-}
-
-a.list-group-item {
-
-  &:hover .list-group-item-heading {
-    text-decoration: underline;
-  }
-
-  .list-group-item-heading {
-    color: $link-color;
-  }
-
 }
 
 /* No content

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -155,11 +155,64 @@
     <p>Purple <code>:visited</code> styles have been added. These apply to the main content but not to buttons.</p>
   </div>
   <div class="col-md-6">
-    <a href="/style" class="link-muted">Muted link</a><br><br>
-    <a href="/style">Visited link</a><br><br>
-    <a href="/style#<%= "#{Time.now.utc.to_i}" %>">Normal link</a><br><br>
-    <a href="/style" class="btn btn-default">Visited button link</a><br><br>
-    <a href="/style" class="btn btn-success">Another visited button link</a><br><br>
+    <a href="/style-guide" class="link-muted">Muted link</a><br><br>
+    <a href="/style-guide">Visited link</a><br><br>
+    <a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>">Normal link</a><br><br>
+    An <a href="/style-guide" class="link-inherit">underlined link</a> that inherits its colour<br><br>
+    <a href="/style-guide" class="btn btn-default">Visited button link</a><br><br>
+    <a href="/style-guide" class="btn btn-success">Another visited button link</a><br><br>
+  </div>
+</div>
+
+<h3>Links in Bootstrap components</h3>
+<div class="row">
+  <div class="col-md-3">
+    <h4 class="add-bottom-margin">List group with content</h4>
+    <div class="list-group">
+      <a href="/style-guide" class="list-group-item active">
+        <h4 class="list-group-item-heading">Active visited link</h4>
+        <p class="list-group-item-text">Active visited link</p>
+      </a>
+      <a href="/style-guide" class="list-group-item">
+        <h4 class="list-group-item-heading">Visited link</h4>
+        <p class="list-group-item-text">Visited link</p>
+      </a>
+      <a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>" class="list-group-item">
+        <h4 class="list-group-item-heading">Normal link</h4>
+        <p class="list-group-item-text">Normal link</p>
+      </a>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <h4 class="add-bottom-margin">List group</h4>
+    <div class="list-group">
+      <a href="/style-guide" class="list-group-item active">
+        Active visited link style
+      </a>
+      <a href="/style-guide" class="list-group-item">Visited link</a>
+      <a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>" class="list-group-item">Normal link</a>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <h4 class="add-bottom-margin">Navigation pills</h4>
+    <ul class="nav nav-pills nav-stacked">
+      <li class="active"><a href="/style-guide">Active visited link</a></li>
+      <li><a href="/style-guide">Visited link</a></li>
+      <li><a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>">Normal link</a></li>
+    </ul>
+  </div>
+  <div class="col-md-3">
+    <h4 class="add-bottom-margin">Dropdowns</h4>
+    <!-- Single button -->
+    <div class="btn-group open">
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        Action <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu">
+        <li><a href="/style-guide">Visited link</a></li>
+        <li><a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>">Normal link</a></li>
+      </ul>
+    </div>
   </div>
 </div>
 <hr>


### PR DESCRIPTION
- Navigation pills, list groups and drop downs shouldn’t go purple when
  they are visited
- Add examples to the style guide to ensure that the visited and
  non-visited states remain consistent

![screen shot 2014-05-30 at 16 26 14](https://cloud.githubusercontent.com/assets/319055/3138813/ecb58faa-e8af-11e3-909e-6bfa8a921f93.png)
![screen shot 2014-05-30 at 16 26 21](https://cloud.githubusercontent.com/assets/319055/3138814/ef3b6808-e8af-11e3-8636-6b0267f61c7d.png)
