### PR TITLE
Allow content in footer and at the bottom of a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ content_for    | Description
 -------------  | -------------
 app_title      | Name of your admin application
 content        | Main content
-footer_version (optional) | Text indicating the release, eg commit SHA
 head           | HTML to include in the <head> of your application
+page_title     | Page title
 navbar_items   | A set of HTML list items (`<li>`) forming the primary navigation
 navbar_right   | Text to the right of the nav bar. Logged in user, sign out link, etc
-page_title     | Page title
+footer_top (optional) | Footer content before copyright text
+footer_version (optional) | Text indicating the release, eg commit SHA
+body_end (optional) | Just before the `</body>` tag
 
 Example navbar_items:
 ```erb

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -53,11 +53,13 @@
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
       <footer class="page-footer">
+        <%= yield :footer_top %>
         <a class="inherit" href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a>
         <% if content_for?(:footer_version) %>
           <span class="pull-right">Version: <%= yield :footer_version %></span>
         <% end %>
       </footer>
     </section>
+    <%= yield :body_end %>
   </body>
 </html>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,17 +1,21 @@
 <%# blocks for govuk_admin_template %>
 <% content_for :page_title do %>page_title<% end %>
+<% content_for :app_title do %>app_title<% end %>
+<% content_for :head do %>
+  <%= stylesheet_link_tag "application", :media => "all" %>
+  <%= javascript_include_tag "application" %>
+<% end %>
+
 <% content_for :navbar_items do %>
   <li>
     <a href="#">navbar_item</a>
   </li>
 <% end %>
 <% content_for :navbar_right do %>navbar_right<% end %>
+
+<% content_for :footer_top do %>footer_top<% end %>
 <% content_for :footer_version do %>footer_version<% end %>
-<% content_for :app_title do %>app_title<% end %>
-<% content_for :head do %>
-  <%= stylesheet_link_tag "application", :media => "all" %>
-  <%= javascript_include_tag "application" %>
-<% end %>
+<% content_for :body_end do %>body_end<% end %>
 
 <%# use the govuk_admin_foundation layout %>
 <%= render :template => 'layouts/govuk_admin_template' %>

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -9,6 +9,8 @@ describe 'Layout' do
     expect(body).to include('navbar_item')
     expect(body).to include('main_content')
     expect(body).to include('footer_version')
+    expect(body).to include('footer_top')
+    expect(body).to include('body_end')
     expect(page).to have_title 'page_title'
   end
 


### PR DESCRIPTION
- Two new options `footer_top` and `body_end`
- `footer_top` is for custom footers
- `body_end` is for markup that should be right at the bottom of the
  page, eg javascript includes
- New options use the same names as `govuk_template` https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb
