### PR TITLE
Restrict bootstrap component visited link styles

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/base.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/base.css.scss
@@ -240,12 +240,9 @@ main a {
   color: $list-group-link-color;
 }
 
-.list-group a.list-group-item.active:visited {
-  color: $list-group-active-text-color;
-}
-
+.list-group a.list-group-item.active:visited,
 .list-group a.list-group-item.active:visited:hover {
-  color: $list-group-active-text-color;
+  color: $component-active-color;
 }
 
 /* List groups with content  */

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -193,6 +193,10 @@
         <h4 class="list-group-item-heading">Active visited link</h4>
         <p class="list-group-item-text">Active visited link</p>
       </a>
+      <a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>" class="list-group-item active">
+        <h4 class="list-group-item-heading">Active normal link</h4>
+        <p class="list-group-item-text">Active normal link</p>
+      </a>
       <a href="/style-guide" class="list-group-item">
         <h4 class="list-group-item-heading">Visited link</h4>
         <p class="list-group-item-text">Visited link</p>
@@ -209,6 +213,9 @@
       <a href="/style-guide" class="list-group-item active">
         Active visited link style
       </a>
+      <a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>" class="list-group-item active">
+        Active normal link style
+      </a>
       <a href="/style-guide" class="list-group-item">Visited link</a>
       <a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>" class="list-group-item">Normal link</a>
     </div>
@@ -217,6 +224,7 @@
     <h4 class="add-bottom-margin">Navigation pills</h4>
     <ul class="nav nav-pills nav-stacked">
       <li class="active"><a href="/style-guide">Active visited link</a></li>
+      <li class="active"><a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>">Active normal link</a></li>
       <li><a href="/style-guide">Visited link</a></li>
       <li><a href="/style-guide#<%= "#{Time.now.utc.to_i}" %>">Normal link</a></li>
       <li>


### PR DESCRIPTION
- Only apply the styles to specified descendants
- eg fixes a situation in Transition where a drop down is nested in a
  navigation pill, which caused broken hover states for visited links
