### PR TITLE
Correct spacing when using Bootstrap's page-header class

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template.scss
+++ b/app/assets/stylesheets/govuk_admin_template.scss
@@ -1,6 +1,6 @@
 @import 'bootstrap';
-@import 'govuk_admin_template/buttons'; // overrides bootstrap buttons
 @import 'govuk_admin_template/theme';
+@import 'govuk_admin_template/bootstrap_overrides';
 @import 'govuk_admin_template/base';
 
 // Components

--- a/app/assets/stylesheets/govuk_admin_template/bootstrap_overrides.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/bootstrap_overrides.css.scss
@@ -1,0 +1,11 @@
+@import 'govuk_admin_template/buttons'; // overrides bootstrap buttons
+
+/*
+  The admin gem's navbar has a bottom margin, for correct spacing
+  when the page-header class isn't used. To account for this reduce
+  the top margin from 40px to 20px, keeping the space effectively
+  the same.
+*/
+.page-header {
+  margin-top: $default-vertical-margin;
+}

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:page_title, 'Admin template style guide') %>
 
-<div class="page-title">
+<div class="page-header">
   <h1>
     Admin template style guide
   </h1>

--- a/spec/dummy/app/views/welcome/index.html.erb
+++ b/spec/dummy/app/views/welcome/index.html.erb
@@ -1,1 +1,3 @@
-<h1>main_content</h1>
+<div class="page-header">
+  <h1>main_content</h1>
+</div>


### PR DESCRIPTION
- Account for the extra margin provided by the navbar, reduce the margin by 20px

![screen shot 2014-06-06 at 16 39 59](https://cloud.githubusercontent.com/assets/319055/3202454/f39b9040-ed90-11e3-9195-45322cde18d4.png)
