### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This gem provides (via a Rails engine):
 
 Firstly, include the gem in your Gemfile, pinned to the appropriate version and run ```bundle```:
 ```ruby
-gem 'govuk-admin-template', '0.0.1'
+gem 'govuk_admin_template', '0.0.1'
 ```
 
 At the top of `application.scss` include the styles (this provides all the mixins and variables from the gem as well as from bootstrap — [bootstrap mixins](https://github.com/twbs/bootstrap-sass/blob/master/vendor/assets/stylesheets/bootstrap/_mixins.scss)):


### PR DESCRIPTION
The name of the gem is actually govuk_admin_template not govuk-admin-template according to http://rubygems.org/gems/govuk_admin_template
