### PR TITLE
Add short date and time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example navbar_items:
 
 ### Date formats
 
-The [gem includes](lib/govuk_admin_template/engine.rb) `:govuk_date` date and time formats which match the [recommended style](https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times).
+The [gem includes](lib/govuk_admin_template/engine.rb) date and time formats which match the [recommended style](https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times).
 
 ```ruby
 # 1 January 2013
@@ -96,6 +96,15 @@ date.to_s(:govuk_date)
 
 # 1:15pm, 1 January 2013
 time.to_s(:govuk_date)
+
+# 1 Jan 2013
+date.to_s(:govuk_date_short)
+
+# 1:15pm, 1 Jan 2013
+time.to_s(:govuk_date_short)
+
+# 1:15pm
+time.to_s(:govuk_time)
 ```
 
 ### Environment indicators

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -54,7 +54,7 @@
 <h2>Dates</h2>
 <div class="row">
   <p class="col-md-6 lead">
-    The gem includes <code>:govuk_date</code> date and time formats which match the <a href="https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times">recommended style</a>.
+    The gem includes date and time formats which match the <a href="https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times">recommended style</a>.
   </p>
   <section class="col-md-6">
     <h2 class="remove-top-margin">Default</h2>
@@ -64,8 +64,17 @@
     </blockquote>
 
     <h2>Friendly</h2>
-    <blockquote><%= halloween.to_s(:govuk_date) %><br />
-      <%= halloween.to_time.to_s(:govuk_date) %>
+    <blockquote>
+      <dl class="remove-bottom-margin">
+        <dt class="add-label-margin"><code>:govuk_date</code></dt>
+        <dd><%= halloween.to_s(:govuk_date) %><br />
+          <%= halloween.to_time.to_s(:govuk_date) %></dd>
+        <dt class="add-top-margin add-label-margin"><code>:govuk_date_short</code></dt>
+        <dd><%= halloween.to_s(:govuk_date_short) %><br />
+          <%= halloween.to_time.to_s(:govuk_date_short) %></dd>
+        <dt class="add-top-margin add-label-margin"><code>:govuk_time</code></dt>
+        <dd><%= halloween.to_time.to_s(:govuk_time) %></dd>
+      </dl>
     </blockquote>
   </section>
 </div>

--- a/lib/govuk_admin_template/engine.rb
+++ b/lib/govuk_admin_template/engine.rb
@@ -13,8 +13,17 @@ module GovukAdminTemplate
       # 1 January 2013
       Date::DATE_FORMATS[:govuk_date] = '%-e %B %Y'
 
+      # 1 Jan 2013
+      Date::DATE_FORMATS[:govuk_date_short] = '%-e %b %Y'
+
       # 1:15pm, 1 January 2013
       Time::DATE_FORMATS[:govuk_date] = '%-I:%M%P, %-e %B %Y'
+
+      # 1:15pm, 1 Jan 2013
+      Time::DATE_FORMATS[:govuk_date_short] = '%-I:%M%P, %-e %b %Y'
+
+      # 1:15pm
+      Time::DATE_FORMATS[:govuk_time] = '%-I:%M%P'
     end
   end
 end

--- a/spec/style_guide/style_guide_spec.rb
+++ b/spec/style_guide/style_guide_spec.rb
@@ -8,9 +8,12 @@ describe 'Style guide' do
     expect(body).to include('Admin template style guide')
   end
 
-  it 'includes a formatted date' do
+  it 'includes formatted dates' do
     visit '/style-guide'
     expect(body).to include('31 October 2013')
     expect(body).to include('12:00am, 31 October 2013')
+
+    expect(body).to include('31 Oct 2013')
+    expect(body).to include('12:00am, 31 Oct 2013')
   end
 end


### PR DESCRIPTION
- Create `govuk_date_short` and `govuk_time`
- Include examples on style guide
- Update documentation
- The content style guide recommends: “when space is an issue, eg
  tables, publication titles etc, you can use truncated months”
