### PR TITLE
Move IE8 shims and fixes so they load after styles

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -11,10 +11,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>(function(d){d.className=d.className.replace(/^no-js\b/,'js');}(document.documentElement));</script>
-    <% # HTML5 and bootstrap shims, for <= IE8 support of HTML5 elements %>
-    <!--[if lte IE 8]>
-      <%= javascript_include_tag "lte-ie8" %>
-    <![endif]-->
     <% # jQuery and Bootstrap %>
     <%= javascript_include_tag "govuk-admin-template" %>
     <% if content_for?(:favicon) %>
@@ -25,6 +21,14 @@
       %>
     <% end %>
     <%= yield :head %>
+    <%
+      # HTML5 and bootstrap shims, for <= IE8 support of HTML5 elements
+      # respond.js must come after CSS (from :head) and media queries so
+      # that rules and styles can be correctly calculated.
+    %>
+    <!--[if lte IE 8]>
+      <%= javascript_include_tag "lte-ie8" %>
+    <![endif]-->
   </head>
   <body<% if environment_style %> class="environment-<%= environment_style %>"<% end %>>
     <header class="


### PR DESCRIPTION
For respond.js to work correctly, it must load after the CSS has loaded (it uses media queries in the CSS files to determine styles to display).

Also, from the docs, “Reference the respond.min.js script (1kb min/gzipped) after all of your CSS (the earlier it runs, the greater chance IE users will not see a flash of un-media'd content)”

Before:
![screen shot 2014-06-26 at 09 07 33](https://cloud.githubusercontent.com/assets/319055/3396108/20f4e0a0-fd09-11e3-9cb9-cb40f112a1ad.png)

After:
![screen shot 2014-06-26 at 09 07 53](https://cloud.githubusercontent.com/assets/319055/3396112/277d3b3e-fd09-11e3-9c35-5cb420afd0bd.png)
