### PR TITLE
Precompile IE7 to a CSS file, not SCSS

### DIFF
--- a/lib/govuk_admin_template/engine.rb
+++ b/lib/govuk_admin_template/engine.rb
@@ -4,7 +4,7 @@ module GovukAdminTemplate
     require 'jquery-rails'
 
     initializer 'govuk_admin_template.assets.precompile' do |app|
-      app.config.assets.precompile += %w(lte-ie8.js govuk-admin-template.js govuk_admin_template/bootstrap-ie7.scss)
+      app.config.assets.precompile += %w(lte-ie8.js govuk-admin-template.js govuk_admin_template/bootstrap-ie7.css)
     end
 
     # User friendly GOV.UK date formats, based on:


### PR DESCRIPTION
- The precompile list needs to list the output filenames, not the source filenames.
