### PR TITLE
Add :before_content content_for block to layout template

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -81,6 +81,7 @@
     </header>
     <section class="container">
       <main role="main">
+        <%= yield(:before_content) %>
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
       <footer class="page-footer">

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -17,5 +17,7 @@
 <% content_for :footer_version do %>footer_version<% end %>
 <% content_for :body_end do %>body_end<% end %>
 
+<% content_for :before_content do %>before_content<% end %>
+
 <%# use the govuk_admin_foundation layout %>
 <%= render :template => 'layouts/govuk_admin_template' %>

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -8,6 +8,7 @@ describe 'Layout' do
     expect(body).to include('navbar_right')
     expect(body).to include('navbar_item')
     expect(body).to include('main_content')
+    expect(body).to include('before_content')
     expect(body).to include('footer_version')
     expect(body).to include('footer_top')
     expect(body).to include('body_end')


### PR DESCRIPTION
This adds a little more flexibility in the layout you can achieve from
a consuming app's layout.

The use case here was the need to have a flash message rendered above
content in the layout. As layouts are rendered after templates, content
can only be appended to the end of a content_for block from a layout,
hence the need for a distinct :before_content content_for block.
