### PR TITLE
Bring `lead` styles more inline with GOV.UK ones

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.css.scss
@@ -9,3 +9,14 @@
 .page-header {
   margin-top: $default-vertical-margin;
 }
+
+/*
+  Bootstrap uses a lighter font weight for text using the lead
+  class. This lighter text is harder to read and looks out of place
+  with all of GOV.UK’s font rendering. Reset back to normal and
+  lighten text colour to maintain balance.
+*/
+.lead {
+  font-weight: normal;
+  color: #555;
+}


### PR DESCRIPTION
Bootstrap uses a lighter font weight for text using the lead class. This lighter text is harder to read and looks out of place with all of GOV.UK’s other font rendering.
- Reset back to normal font weight
- Lighten text colour to maintain balance
## Before

![screen shot 2014-09-05 at 14 13 13](https://cloud.githubusercontent.com/assets/319055/4165090/9de9137e-34fe-11e4-9dca-5d021f5a5547.png)
## After

![screen shot 2014-09-05 at 14 12 56](https://cloud.githubusercontent.com/assets/319055/4165089/9dd33f72-34fe-11e4-94a8-6c21e54a9d0d.png)
