### PR TITLE
Bump version to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.4
+
+* Fix missing assets in production Rails 4 apps, both our own (header-crown.png)
+  and Bootstrap's glyphicon font-using bits
+
 # 1.1.3
 
 * Fix GillSans font stack for IE and Chrome on Windows

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
- Fixes missing assets in production Rails 4 apps, both our own
  (header-crown.png) and Bootstrap's glyphicon font-using bits
