### PR TITLE
Bump version to 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.5
+
+* Move gem management-related rake tasks to ./tasks to avoid breaking consuming
+  apps that auto-load tasks from lib/tasks
+
 # 1.1.4
 
 * Fix missing assets in production Rails 4 apps, both our own (header-crown.png)

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "1.1.4"
+  VERSION = "1.1.5"
 end


### PR DESCRIPTION
Fix a break to consuming apps' rake tasks due to autoload from `lib/tasks`
