### PR TITLE
Really fix the crown

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_navbar.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_navbar.css.scss
@@ -4,7 +4,7 @@
 
 .navbar .container .navbar-brand,
 .navbar .container-fluid .navbar-brand {
-  background: image-url("/assets/govuk_admin_template/header-crown.png") 0 0.67em no-repeat;
+  background: image-url("govuk_admin_template/header-crown.png") 0 0.67em no-repeat;
   color: #fff;
   font-family: $font-family-gill-sans;
   font-size: 20px;

--- a/tasks/sass/check.rake
+++ b/tasks/sass/check.rake
@@ -1,14 +1,16 @@
-UNGUARDED_URL_USAGE = /\surl\(/
+UNGUARDED_URL_USAGE  = /\surl\(/
+ABSOLUTE_ASSET_USAGE = /(?:image-path|image-url|asset-path|asset-url)\(["']\/assets/
 
 namespace :sass do
-  desc 'Check all SCSS for unguarded url() usages'
+  desc 'Check all SCSS for 404-creating problems'
   task :check do
     scss_files = File.expand_path(
-        '../../../../app/assets/stylesheets/**/*.scss', __FILE__)
+        '../../../app/assets/stylesheets/**/*.scss', __FILE__)
 
     matching_lines = Dir[scss_files].inject([]) do |matching, scss_file|
       File.readlines(scss_file).each_with_index do |line, number|
-        matching << "#{scss_file}:#{number + 1}" if line =~ UNGUARDED_URL_USAGE
+        matching << "Unguarded url usage: #{scss_file}:#{number + 1}"    if line =~ UNGUARDED_URL_USAGE
+        matching << "Absolute /assets usage: #{scss_file}:#{number + 1}" if line =~ ABSOLUTE_ASSET_USAGE
       end
       matching
     end
@@ -16,13 +18,32 @@ namespace :sass do
     if matching_lines.any?
       raise <<-MSG
 
-Do not use instances of url(...) to refer to images within this gem.
-Prefer the SASS function image-url. Unguarded url references won't work in
-Rails 4 and up due to MD5 hashes in asset filenames. Your asset will 404 in
-production Rails 4 apps.
+One or more problems exist:
 
-Lines that use url(...) to refer to images within this gem:
+Unguarded url usage
+-------------------
 
+  Do not use instances of url(...) to refer to images within this gem.
+  Prefer the SASS function image-url. Unguarded url references won't work in
+  Rails 4 and up due to MD5 hashes in asset filenames. Your asset will 404 in
+  production Rails 4 apps.
+
+Absolute /assets usage
+----------------------
+
+  When using any of the image/asset helpers, don't refer to /assets absolutely.
+  For example,
+
+    image-url('/assets/govuk_admin_template/header-crown.png')
+
+  should instead be
+
+    image-url('govuk_admin_template/header-crown.png')
+
+  If Sprockets can't find the image on precompilation, it won't rewrite the
+  URL and will pass it through unaltered. This usually means it will 404.
+
+Problems:
       #{matching_lines.join("\n  ")}
 
       MSG


### PR DESCRIPTION
- can't just use image-url(...) as a drop-in replacement for url(...)
- Input to image-url has to be relative to the assets path (/assets is a
  no-no)
- Update the sass:check to reflect this (while also fixing the path that
  should have been moved at the same time as the rake tasks were)

In #42 we said we'd fixed this, and we tested it using a shonky manual method (for reasons described therein).  Unfortunately `assets:precompile` locally also generated the unadorned filename (because `spec/dummy` is a Rails 3 app) so we weren't actually testing what we thought we were.
