### PR TITLE
Bump version to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.6
+
+* Really fix the crown this time (`image-url` requires a gem-relative path)
+
 # 1.1.5
 
 * Move gem management-related rake tasks to ./tasks to avoid breaking consuming

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "1.1.5"
+  VERSION = "1.1.6"
 end


### PR DESCRIPTION
- Really fix the crown this time (`image-url` requires gem-relative
  paths)
