### PR TITLE
Add a callout component

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_base.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_base.css.scss
@@ -400,6 +400,57 @@ a.list-group-item {
 }
 
 /* ==========================================================================
+   Callouts
+   ========================================================================== */
+
+.callout {
+  border: 1px solid $table-border-color;
+  border-radius: $border-radius-small;
+  padding: $default-vertical-padding;
+
+  .callout-title {
+    margin-top: 0;
+    font-size: $font-size-h4;
+  }
+
+  .callout-body {
+    font-size: $font-size-h3;
+  }
+}
+
+.callout-danger {
+  border-left: 5px solid #d9534f;
+
+  .callout-title {
+    color: $state-danger-text;
+  }
+}
+
+.callout-warning {
+  border-left: 5px solid #f0ad4e;
+
+  .callout-title {
+    color: $state-warning-text;
+  }
+}
+
+.callout-info {
+  border-left: 5px solid #5bc0de;
+
+  .callout-title {
+    color: $state-info-text;
+  }
+}
+
+.callout-success {
+  border-left: 5px solid #53ad53;
+
+  .callout-title {
+    color: $state-success-text;
+  }
+}
+
+/* ==========================================================================
    Forms
    ========================================================================== */
 

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -440,6 +440,49 @@
 </div>
 <hr>
 
+<h2>Callouts</h2>
+<div class="row">
+  <p class="col-md-6 lead">A component for drawing attention to particular content, which is more subtle than a highlight.</p>
+  <div class="col-md-6">
+    <div class="callout callout-danger">
+      <div class="callout-title">
+        Important note
+      </div>
+      <div class="callout-body">
+        Don’t merge yet!
+      </div>
+    </div>
+
+    <div class="callout callout-warning">
+      <div class="callout-title">
+        Proceed
+      </div>
+      <div class="callout-body">
+        But with caution.
+      </div>
+    </div>
+
+    <div class="callout callout-info">
+      <div class="callout-title">
+        Just for your info
+      </div>
+      <div class="callout-body">
+        Carry on.
+      </div>
+    </div>
+
+    <div class="callout callout-success">
+      <div class="callout-title">
+        All’s well
+      </div>
+      <div class="callout-body">
+        Yay.
+      </div>
+    </div>
+  </div>
+</div>
+<hr>
+
 <h2>No content</h2>
 <div class="row">
   <p class="col-md-6 lead">A large but light style which applies to the empty state. The bordered version mimics bootstrap table styles.</p>


### PR DESCRIPTION
This is cribbed from the [callouts used in the Bootstrap documentation](http://getbootstrap.com/components/#glyphicons-how-to-use).

![image](https://cloud.githubusercontent.com/assets/23801/5143027/0c28402e-7183-11e4-84c0-f2e9d051395e.png)

/cc @fofr I suspect that the SASS could be a bit drier?
