### PR TITLE
Upgrade Bootstrap to 3.3

### DIFF
--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'sass-rails', '3.2.6'
   gem.add_development_dependency 'rspec-rails', '2.14.2'
-  gem.add_development_dependency 'capybara', '2.2.1'
+  gem.add_development_dependency 'capybara', '2.4.4'
   gem.add_development_dependency 'gem_publisher', '1.3.1'
   gem.add_development_dependency 'jasmine', '2.1.0'
 end


### PR DESCRIPTION
http://blog.getbootstrap.com/2014/10/29/bootstrap-3-3-0-released/
https://github.com/twbs/bootstrap/releases/tag/v3.3.0

Also bumps jasmine and capybara gems for gem development.

Tested with Publisher master and generated style guides to check for regressions.

https://www.agileplannerapp.com/boards/173808/cards/8761
