### PR TITLE
Allow customisation of app's home path

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_renderin
 `content_for`     | Description
 ---------------   | -------------
 `:app_title`      | Name of your admin application
+`:app_home_path`  | Path to the home page of your application, defaults to `root_path`
 `:content`        | Main content
 `:head`           | HTML to include in the `<head>` of your application
 `:page_title`     | Page title

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -1,6 +1,7 @@
 <%
   environment_style = GovukAdminTemplate.environment_style
   environment_label = GovukAdminTemplate.environment_label
+  app_home_path = content_for?(:app_home_path) ? yield(:app_home_path) : root_path
 %>
 <!DOCTYPE html>
 <!--[if lte IE 7]><html class="no-js lte-ie7" lang="en"><![endif]-->
@@ -54,7 +55,7 @@
               <span class="icon-bar"></span>
             </a>
           <% end %>
-          <%= link_to content_for?(:app_title) ? yield(:app_title) : "GOV.UK", root_path, :class => 'navbar-brand' %>
+          <%= link_to content_for?(:app_title) ? yield(:app_title) : "GOV.UK", app_home_path, :class => 'navbar-brand' %>
           <% if environment_label %>
             <div class="environment-label">
               <%= environment_label %>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <%# blocks for govuk_admin_template %>
 <% content_for :page_title do %>page_title<% end %>
 <% content_for :app_title do %>GOV.UK app_title<% end %>
+<% content_for :app_home_path, govuk_admin_template_engine_path %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= javascript_include_tag "application" %>

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -34,6 +34,11 @@ describe 'Layout' do
     end
   end
 
+  it 'renders a link to a custom home path' do
+    visit '/'
+    expect(page).to have_selector('a[href="/style-guide"]', text: 'app_title')
+  end
+
   it 'renders a bootstrap header' do
     visit '/'
     within '.navbar' do


### PR DESCRIPTION
HMRC contacts app puts its homepage within an admin namespace, so the crown link in the head needs to be modifiable.
- Introduce an `app_home_path` variable
- Default it to `root_path` for backwards compatibility
