### PR TITLE
Upgrade Bootstrap to 3.3.2

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_navbar.css.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_navbar.css.scss
@@ -48,8 +48,16 @@ header .navbar-header {
 }
 
 .navbar-text a {
-  color: $gray-light;
+  color: $navbar-inverse-link-color;
   text-decoration: underline;
+
+  &:hover {
+    color: $navbar-inverse-link-hover-color;
+  }
+
+  &:active {
+    color: $navbar-inverse-link-active-color;
+  }
 }
 
 // Let's make these more specific to add the intended white colour

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -6,7 +6,7 @@
   </h1>
 </div>
 
-<p class="lead">Admin app UIs are powered by <a href="http://getbootstrap.com/css/">bootstrap 3.2</a>, using <a href="https://github.com/twbs/bootstrap-sass/tree/v3.2.0">bootstrap SASS</a> v3.2.0 (<a href="https://github.com/twbs/bootstrap-sass/blob/v3.2.0/assets/stylesheets/bootstrap/_mixins.scss">mixins</a>), but maintaining bootstrap 2 button styles. This guide documents how we use bootstrap, where the apps have diverged from default styles and any custom styles needed to fill in the gaps.</p>
+<p class="lead">Admin app UIs are powered by <a href="http://getbootstrap.com/css/">bootstrap 3.3.2</a>, using <a href="https://github.com/twbs/bootstrap-sass/tree/v3.3.3">bootstrap SASS</a> v3.3.3 (<a href="https://github.com/twbs/bootstrap-sass/blob/v3.3.3/assets/stylesheets/bootstrap/_mixins.scss">mixins</a>), but maintaining bootstrap 2 button styles. This guide documents how we use bootstrap, where the apps have diverged from default styles and any custom styles needed to fill in the gaps.</p>
 
 <h2>Grid</h2>
 <p class="lead">Apps use the <a href="http://getbootstrap.com/css/#grid">default bootstrap</a> <strong>12 column scaleable responsive grid</strong>.</p>

--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'rails', '>= 3.2.0'
-  gem.add_dependency 'bootstrap-sass', '~> 3.3.1'
+  gem.add_dependency 'bootstrap-sass', '~> 3.3.3'
   gem.add_dependency 'jquery-rails', '~> 3.1.1'
 
   gem.add_development_dependency 'sass-rails', '3.2.6'

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <a href="#">navbar_item</a>
   </li>
 <% end %>
-<% content_for :navbar_right do %>navbar_right<% end %>
+<% content_for :navbar_right do %><a href="/">navbar_right</a><% end %>
 
 <% content_for :footer_top do %>footer_top<% end %>
 <% content_for :footer_version do %>footer_version<% end %>


### PR DESCRIPTION
via upgrading bootstrap-sass to v3.3.3

https://github.com/twbs/bootstrap-sass/blob/master/CHANGELOG.md
https://github.com/twbs/bootstrap/releases/tag/v3.3.2
http://blog.getbootstrap.com/2015/01/19/bootstrap-3-3-2-released/

Main changes in this release:
* New glyphicons
* New dependency on autoprefixer-rails:
https://github.com/ai/autoprefixer-rails (which we should have already been using it seems). See also https://github.com/twbs/bootstrap-sass/issues/824

Tested against publisher and found no regressions.