### PR TITLE
Include Google Analytics tracking code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This gem provides (via a Rails engine):
 * Admin design patterns available from `/style-guide` (when routes are mounted)
 * [CSS helpers and SASS variables](CSS.md) for the admin theme
 * GOV.UK user friendly date formats
+* Google Analytics tracking code (Universal Analytics), using the "GOV.UK apps" profile
 
 [Apps using this gem](https://github.com/search?q=govuk_admin_template+user%3Aalphagov+filename%3AGemfile) include:
 * [Transition](https://github.com/alphagov/transition)

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -71,10 +71,16 @@
   }
 
   // Google Analytics pageview tracking
-  GOVUKAdmin.trackPageview = function(path) {
+  GOVUKAdmin.trackPageview = function(path, title) {
+    var pageviewObject = { page: path };
+
+    if (typeof title === "string") {
+      pageviewObject.title = title;
+    }
+
     if (typeof root.ga === "function") {
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
-      root.ga('send', 'pageview', path);
+      root.ga('send', 'pageview', pageviewObject);
     }
   }
 

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -70,9 +70,17 @@
     window.location.href = path;
   }
 
+  // Google Analytics pageview tracking
+  GOVUKAdmin.trackPageview = function(path) {
+    if (typeof root.ga === "function") {
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
+      root.ga('send', 'pageview', path);
+    }
+  }
+
   // Google Analytics event tracking
   // Label and value are optional
-  GOVUKAdmin.track = function(action, label, value) {
+  GOVUKAdmin.trackEvent = function(action, label, value) {
 
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
     // Default category to the page an event occurs on

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -74,22 +74,16 @@
   // Label and value are optional
   GOVUKAdmin.track = function(action, label, value) {
 
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
     // Default category to the page an event occurs on
-    var category = root.location.pathname,
-
-        // https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
-        eventGa = ["_trackEvent", category, action],
-
-        // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
-        eventAnalytics = {
+    var eventAnalytics = {
           hitType: 'event',
-          eventCategory: category,
+          eventCategory: root.location.pathname,
           eventAction: action
         };
 
     // Label is optional
     if (typeof label === "string") {
-      eventGa.push(label);
       eventAnalytics.eventLabel = label;
     }
 
@@ -99,18 +93,13 @@
     if (value) {
       value = parseInt(value, 10);
       if (typeof value === "number" && !isNaN(value)) {
-        eventGa.push(value);
         eventAnalytics.eventValue = value;
       }
     }
 
-    // _gaq is the Google Analytics tracking object we
-    // push events to when using the old tracking code
-    root._gaq = root._gaq || [];
-
     // Useful for debugging:
-    // console.log(eventGa, eventAnalytics);
-    root._gaq.push(eventGa);
+    // console.log(eventAnalytics);
+
     if (typeof root.ga === "function") {
       root.ga('send', eventAnalytics);
     }

--- a/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js
@@ -8,7 +8,7 @@
           label = element.data('track-label'),
           value = element.data('track-value');
 
-      GOVUKAdmin.track(action, label, value);
+      GOVUKAdmin.trackEvent(action, label, value);
     }
   };
 

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -91,5 +91,16 @@
       </footer>
     </section>
     <%= yield :body_end %>
+    <% if Rails.env.production? %>
+      <script class="analytics">
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-26179049-6', 'alphagov.co.uk');
+        ga('send', 'pageview');
+      </script>
+    <% end %>
   </body>
 </html>

--- a/spec/javascripts/spec/auto_track_event.spec.js
+++ b/spec/javascripts/spec/auto_track_event.spec.js
@@ -15,8 +15,8 @@ describe('An auto event tracker', function() {
   });
 
   it('tracks events on start', function() {
-    spyOn(root.GOVUKAdmin, 'track');
+    spyOn(root.GOVUKAdmin, 'trackEvent');
     tracker.start(element);
-    expect(GOVUKAdmin.track).toHaveBeenCalledWith('action', 'label', 10)
+    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('action', 'label', 10)
   });
 });

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -85,12 +85,19 @@ describe('A GOVUKAdmin app', function() {
   });
 
   describe('when pageviews are tracked', function() {
-    it('sends them to Google Analytics', function() {
+    beforeEach(function() {
       window.ga = function() {};
       spyOn(window, 'ga');
-      GOVUKAdmin.trackPageview('/nicholas-page');
+    });
 
-      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', '/nicholas-page']);
+    it('sends them to Google Analytics', function() {
+      GOVUKAdmin.trackPageview('/nicholas-page');
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', {page: '/nicholas-page'}]);
+    });
+
+    it('can track a custom title', function() {
+      GOVUKAdmin.trackPageview('/nicholas-page', 'Nicholas Page');
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', {page: '/nicholas-page', title: 'Nicholas Page'}]);
     });
   });
 

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -84,6 +84,16 @@ describe('A GOVUKAdmin app', function() {
     });
   });
 
+  describe('when pageviews are tracked', function() {
+    it('sends them to Google Analytics', function() {
+      window.ga = function() {};
+      spyOn(window, 'ga');
+      GOVUKAdmin.trackPageview('/nicholas-page');
+
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', '/nicholas-page']);
+    });
+  });
+
   describe('when events are tracked', function() {
 
     beforeEach(function() {
@@ -96,32 +106,32 @@ describe('A GOVUKAdmin app', function() {
     }
 
     it('uses the current path as the category', function() {
-      GOVUKAdmin.track('action', 'label');
+      GOVUKAdmin.trackEvent('action', 'label');
       expect(eventObjectFromSpy()['eventCategory']).toBe('/');
     });
 
     it('sends them to Google Analytics', function() {
-      GOVUKAdmin.track('action', 'label');
+      GOVUKAdmin.trackEvent('action', 'label');
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {hitType: 'event', eventCategory: '/', eventAction: 'action', eventLabel: 'label'}]
       );
     });
 
     it('label is optional', function() {
-      GOVUKAdmin.track('action');
+      GOVUKAdmin.trackEvent('action');
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {hitType: 'event', eventCategory: '/', eventAction: 'action'}]
       );
     });
 
     it('only sends values if they are parseable as numbers', function() {
-      GOVUKAdmin.track('action', 'label', '10');
+      GOVUKAdmin.trackEvent('action', 'label', '10');
       expect(eventObjectFromSpy()['eventValue']).toEqual(10);
 
-      GOVUKAdmin.track('action', 'label', 10);
+      GOVUKAdmin.trackEvent('action', 'label', 10);
       expect(eventObjectFromSpy()['eventValue']).toEqual(10);
 
-      GOVUKAdmin.track('action', 'label', 'not a number');
+      GOVUKAdmin.trackEvent('action', 'label', 'not a number');
       expect(eventObjectFromSpy()['eventValue']).toEqual(undefined);
     });
   });

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -87,7 +87,6 @@ describe('A GOVUKAdmin app', function() {
   describe('when events are tracked', function() {
 
     beforeEach(function() {
-      window._gaq = [];
       window.ga = function() {};
       spyOn(window, 'ga');
     });
@@ -98,27 +97,18 @@ describe('A GOVUKAdmin app', function() {
 
     it('uses the current path as the category', function() {
       GOVUKAdmin.track('action', 'label');
-      expect(window._gaq[0][1]).toEqual('/');
       expect(eventObjectFromSpy()['eventCategory']).toBe('/');
     });
 
     it('sends them to Google Analytics', function() {
       GOVUKAdmin.track('action', 'label');
-      expect(window._gaq).toEqual([['_trackEvent', '/', 'action', 'label']]);
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {hitType: 'event', eventCategory: '/', eventAction: 'action', eventLabel: 'label'}]
       );
     });
 
-    it('creates a _gaq object when one isn\'t already present', function() {
-      delete window._gaq;
-      GOVUKAdmin.track('action');
-      expect(window._gaq).toEqual([['_trackEvent', '/', 'action']]);
-    });
-
     it('label is optional', function() {
       GOVUKAdmin.track('action');
-      expect(window._gaq).toEqual([['_trackEvent', '/', 'action']]);
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {hitType: 'event', eventCategory: '/', eventAction: 'action'}]
       );
@@ -126,15 +116,12 @@ describe('A GOVUKAdmin app', function() {
 
     it('only sends values if they are parseable as numbers', function() {
       GOVUKAdmin.track('action', 'label', '10');
-      expect(window._gaq[0]).toEqual(['_trackEvent', '/', 'action', 'label', 10]);
       expect(eventObjectFromSpy()['eventValue']).toEqual(10);
 
       GOVUKAdmin.track('action', 'label', 10);
-      expect(window._gaq[1]).toEqual(['_trackEvent', '/', 'action', 'label', 10]);
       expect(eventObjectFromSpy()['eventValue']).toEqual(10);
 
       GOVUKAdmin.track('action', 'label', 'not a number');
-      expect(window._gaq[2]).toEqual(['_trackEvent', '/', 'action', 'label']);
       expect(eventObjectFromSpy()['eventValue']).toEqual(undefined);
     });
   });

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -72,4 +72,17 @@ describe 'Layout' do
       expect(page).to have_selector('a', text: 'Crown Copyright')
     end
   end
+
+  it 'does not include analytics in development' do
+    visit '/'
+    expect(page).to have_no_selector('script.analytics', visible: false)
+  end
+
+  describe 'in production' do
+    before { Rails.env.stub(:production? => true) }
+    it 'includes analytics' do
+      visit '/'
+      expect(page).to have_selector('script.analytics', visible: false)
+    end
+  end
 end


### PR DESCRIPTION
All apps except Transition currently use the same tracking code and ID (Transition should be updated to use this too), which makes the code something that can be consistently added to all apps. This will prevent new apps from forgetting to include analytics.

* Use the GOV.UK apps profile ID
* Only include analytics in a Rails production environment (this includes preview), matching existing implementations.
* Make it easier to track events and pageviews using `GOVUKAdmin.trackEvent` and `GOVUKAdmin.trackPageview`.

This is a breaking change and apps updating will need to ensure they remove their own tracking code and update uses of `GOVUKAdmin.track`.