### PR TITLE
Anonymise IP addresses

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -99,6 +99,7 @@
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
         ga('create', 'UA-26179049-6', 'alphagov.co.uk');
+        ga('set', 'anonymizeIp', true);
         ga('send', 'pageview');
       </script>
     <% end %>


### PR DESCRIPTION
As per https://github.com/alphagov/static/pull/544, we should be stripping off the last octet of IP addresses before sending them to GA.