### PR TITLE
Allow content immediately after opening body tag

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -37,6 +37,7 @@
     <![endif]-->
   </head>
   <body<% if environment_style %> class="environment-<%= environment_style %>"<% end %>>
+    <%= yield :body_start %>
     <header class="
       navbar
       navbar-default

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
 
 <% content_for :footer_top do %>footer_top<% end %>
 <% content_for :footer_version do %>footer_version<% end %>
+<% content_for :body_start do %>body_start<% end %>
 <% content_for :body_end do %>body_end<% end %>
 
 <%# use the govuk_admin_template layout %>

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -10,6 +10,7 @@ describe 'Layout' do
     expect(body).to include('main_content')
     expect(body).to include('footer_version')
     expect(body).to include('footer_top')
+    expect(body).to include('body_start')
     expect(body).to include('body_end')
     expect(page).to have_title 'page_title'
   end


### PR DESCRIPTION
Yields content for `:body_start` immediately after the opening `<body>` tag.

In this instance this is to allow Google Tag Manager code to be inserted as per their instructions.