### PR TITLE
Allow default Google Analytics code to be disabled

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -92,7 +92,7 @@
       </footer>
     </section>
     <%= yield :body_end %>
-    <% if Rails.env.production? %>
+    <% if GovukAdminTemplate.google_analytics? %>
       <script class="analytics">
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/lib/govuk_admin_template.rb
+++ b/lib/govuk_admin_template.rb
@@ -2,7 +2,7 @@ require "govuk_admin_template/version"
 require "govuk_admin_template/engine"
 
 module GovukAdminTemplate
-  mattr_accessor :environment_style, :environment_label
+  mattr_accessor :environment_style, :environment_label, :google_analytics
 
   def self.environment_style
     @@environment_style || self.default_environment_style
@@ -18,5 +18,13 @@ module GovukAdminTemplate
     if Rails.env.development?
       "development"
     end
+  end
+
+  def self.google_analytics
+    @@google_analytics || Rails.env.production?
+  end
+
+  def self.google_analytics?
+    !!self.google_analytics
   end
 end

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -92,7 +92,7 @@ describe 'Layout' do
   context 'analytics is enabled' do
     before { GovukAdminTemplate.google_analytics = true }
 
-    it 'does not include analytics' do
+    it 'does include analytics' do
       visit '/'
       expect(page).to have_selector('script.analytics', visible: false)
     end

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -74,16 +74,36 @@ describe 'Layout' do
     end
   end
 
-  it 'does not include analytics in development' do
-    visit '/'
-    expect(page).to have_no_selector('script.analytics', visible: false)
+  context 'analytics is default' do
+    it 'does not include analytics in development' do
+      visit '/'
+      expect(page).to have_no_selector('script.analytics', visible: false)
+    end
+
+    describe 'in production' do
+      before { Rails.env.stub(:production? => true) }
+      it 'includes analytics' do
+        visit '/'
+        expect(page).to have_selector('script.analytics', visible: false)
+      end
+    end
   end
 
-  describe 'in production' do
-    before { Rails.env.stub(:production? => true) }
-    it 'includes analytics' do
+  context 'analytics is enabled' do
+    before { GovukAdminTemplate.google_analytics = true }
+
+    it 'does not include analytics' do
       visit '/'
       expect(page).to have_selector('script.analytics', visible: false)
+    end
+  end
+
+  context 'analytics is disabled' do
+    before { GovukAdminTemplate.google_analytics = false }
+
+    it 'does not include analytics' do
+      visit '/'
+      expect(page).to have_no_selector('script.analytics', visible: false)
     end
   end
 end


### PR DESCRIPTION
For wider usage of the template it is not desirable to have analytics data sent to the alphagov.co.uk Google Analytics account.