### PR TITLE
Add a confirm javascript module

### DIFF
--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -100,6 +100,7 @@ File   | Module | Attribute | Description
 ------ | ------ | --------- | -----------
 auto_show_modal.js | `AutoShowModal` | `auto-show-modal` | Initialise a Bootstrap modal on page load and remove markup when closed
 auto_track_event.js | `AutoTrackEvent` | `auto-track-event` | Use data attributes to track events in Google Analytics on page load
+confirm.js | `Confirm` | `confirm` | Show a [window.confirm](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) dialogue when a link is clicked
 filterable_table.js | `FilterableTable` | `filterable-table` | Filter the contents of a table, showing only matching rows
 fixed_table_header.js | `FixedTableHeader` | `fixed-table-header` | Fix the `<thead>` portion of a table when scrolling offscreen
 toggle.js | `Toggle` | `toggle` | A simple toggle

--- a/app/assets/javascripts/govuk-admin-template/modules/confirm.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/confirm.js
@@ -1,0 +1,21 @@
+/*
+  Show a confirm dialogue before continuing:
+  <a href="#" data-module="confirm" data-message="Are you sure?">Delete this</a>
+*/
+(function(Modules) {
+  "use strict";
+
+  Modules.Confirm = function() {
+    this.start = function(element) {
+      element.on('click', confirm);
+
+      function confirm(evt) {
+        var message = element.data('message');
+        if (! window.confirm(message)) {
+          evt.preventDefault();
+        }
+      }
+    };
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/spec/javascripts/spec/confirm.spec.js
+++ b/spec/javascripts/spec/confirm.spec.js
@@ -1,0 +1,45 @@
+describe('A confirm module', function() {
+  "use strict";
+
+  var confirm,
+      element,
+      prevented;
+
+  beforeEach(function() {
+    element = $('<a href="#" data-message="some message">Link</a>');
+    parent = $('<div></div>');
+    parent.append(element);
+    confirm = new GOVUKAdmin.Modules.Confirm();
+    confirm.start(element);
+
+    prevented = undefined;
+    parent.on('click', 'a', function(event) {
+      prevented = event.isDefaultPrevented();
+    });
+  });
+
+  describe('when clicking a confirm link', function() {
+
+    it('asks a question before continuing', function() {
+      spyOn(window, 'confirm');
+      element.trigger('click');
+      expect(window.confirm).toHaveBeenCalledWith('some message');
+    });
+
+    describe('when confirming', function() {
+      it('continues loading the requested link', function() {
+        spyOn(window, 'confirm').and.returnValue(true);
+        element.trigger('click');
+        expect(prevented).toBe(false);
+      });
+    });
+
+    describe('when cancelling', function() {
+      it('stops loading the requested link', function() {
+        spyOn(window, 'confirm').and.returnValue(false);
+        element.trigger('click');
+        expect(prevented).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Make it easy to display a [window.confirm](https://developer.mozilla.org/en-US/docs/Web/API/Window
/confirm) dialogue with a custom message when a link is clicked:

```html
<a href="#" data-module="confirm" data-message="Are you sure?">Do a thing</a>
```

Useful as part of:
https://www.pivotaltracker.com/story/show/90529348
> As a Specialist Publisher user, I want to avoid accidentally publishing content items I've created so that I don't risk the reputation of the place I work.

cc @jackscotti 