### PR TITLE
Allow apps to render a custom navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_renderin
 `:footer_version` (optional) | Text indicating the release, eg commit SHA
 `:body_end` (optional) | Just before the `</body>` tag
 `:full_width` (optional, boolean) | Expand content to edges of screen. Must be used on a per-page basis. Apps must not be full width by default.
+`:navbar` (optional) | Custom navbar content, overrides default navbar
 
 Example navbar_items:
 ```erb

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -38,47 +38,51 @@
   </head>
   <body<% if environment_style %> class="environment-<%= environment_style %>"<% end %>>
     <%= yield :body_start %>
-    <header class="
-      navbar
-      navbar-default
-      navbar-inverse
-      navbar-static-top
-      <% if environment_style %>environment-indicator<% end %>
-      add-bottom-margin" role="banner">
-      <div class="<%= content_for?(:full_width) ? 'container-fluid' : 'container' %>">
-        <div class="navbar-header">
-          <% if content_for?(:navbar_right) || content_for?(:navbar_items) %>
-            <%# Bootstrap toggle for collapsed navbar content, used at smaller widths %>
-            <a class="navbar-toggle" data-toggle="collapse" data-target="header .navbar-collapse">
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </a>
-          <% end %>
-          <%= link_to content_for?(:app_title) ? yield(:app_title) : "GOV.UK", app_home_path, :class => 'navbar-brand' %>
-          <% if environment_label %>
-            <div class="environment-label">
-              <%= environment_label %>
-            </div>
-          <% end %>
-        </div>
-        <% if content_for?(:navbar_right) || content_for?(:navbar_items) %>
-          <nav role="navigation" class="collapse navbar-collapse">
-            <% if content_for?(:navbar_items) %>
-              <ul class="nav navbar-nav">
-                <%= yield :navbar_items %>
-              </ul>
+    <% if content_for?(:navbar) %>
+      <%= yield(:navbar) %>
+    <% else %>
+      <header class="
+        navbar
+        navbar-default
+        navbar-inverse
+        navbar-static-top
+        <% if environment_style %>environment-indicator<% end %>
+        add-bottom-margin" role="banner">
+        <div class="<%= content_for?(:full_width) ? 'container-fluid' : 'container' %>">
+          <div class="navbar-header">
+            <% if content_for?(:navbar_right) || content_for?(:navbar_items) %>
+              <%# Bootstrap toggle for collapsed navbar content, used at smaller widths %>
+              <a class="navbar-toggle" data-toggle="collapse" data-target="header .navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </a>
             <% end %>
-            <% if content_for?(:navbar_right) %>
-              <div class="navbar-text pull-right">
-                <%= yield :navbar_right %>
+            <%= link_to content_for?(:app_title) ? yield(:app_title) : "GOV.UK", app_home_path, :class => 'navbar-brand' %>
+            <% if environment_label %>
+              <div class="environment-label">
+                <%= environment_label %>
               </div>
             <% end %>
-          </nav>
-        <% end %>
-      </div>
-    </header>
+          </div>
+          <% if content_for?(:navbar_right) || content_for?(:navbar_items) %>
+            <nav role="navigation" class="collapse navbar-collapse">
+              <% if content_for?(:navbar_items) %>
+                <ul class="nav navbar-nav">
+                  <%= yield :navbar_items %>
+                </ul>
+              <% end %>
+              <% if content_for?(:navbar_right) %>
+                <div class="navbar-text pull-right">
+                  <%= yield :navbar_right %>
+                </div>
+              <% end %>
+            </nav>
+          <% end %>
+        </div>
+      </header>
+    <% end %>
     <section class="<%= content_for?(:full_width) ? 'container-fluid' : 'container' %>">
       <main role="main">
         <%= content_for?(:content) ? yield(:content) : yield %>

--- a/spec/dummy/app/views/welcome/navbar.html.erb
+++ b/spec/dummy/app/views/welcome/navbar.html.erb
@@ -1,0 +1,3 @@
+<% content_for :navbar do %>
+  <h1>custom navbar</h1>
+<% end %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,4 +2,5 @@ Dummy::Application.routes.draw do
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   root :to => 'welcome#index'
   match '/full-width' => 'welcome#full_width'
+  match '/navbar' => 'welcome#navbar'
 end

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -67,6 +67,14 @@ describe 'Layout' do
     expect(page).to have_selector('body > section.container-fluid')
   end
 
+  it 'can render a custom navbar' do
+    visit '/navbar'
+    expect(body).not_to include('app_title')
+    expect(body).not_to include('navbar_right')
+    expect(body).not_to include('navbar_item')
+    expect(page).to have_selector('h1', text: 'custom navbar')
+  end
+
   it 'renders a footer' do
     visit '/'
     within 'footer' do


### PR DESCRIPTION
To switch Whitehall to use the `govuk_admin_template` we need to allow an alternative navbar to be used. Ideally Whitehall would be consistent with other apps.

Part of https://www.pivotaltracker.com/story/show/96072212