### PR TITLE
Workaround interpolation bug in libsass

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_mixins.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_mixins.scss
@@ -4,27 +4,27 @@
 }
 
 @mixin add-top-margin($important: "") {
-  margin-top: $default-vertical-margin #{$important};
+  margin-top: $default-vertical-margin unquote($important);
 }
 
 @mixin remove-top-margin($important: "") {
-  margin-top: 0 #{$important};
+  margin-top: 0 unquote($important);
 }
 
 @mixin add-bottom-margin($important: "") {
-  margin-bottom: $default-vertical-margin #{$important};
+  margin-bottom: $default-vertical-margin unquote($important);
 }
 
 @mixin remove-bottom-margin($important: "") {
-  margin-bottom: 0 #{$important};
+  margin-bottom: 0 unquote($important);
 }
 
 @mixin add-right-margin($important: "") {
-  margin-right: $default-horizontal-margin #{$important};
+  margin-right: $default-horizontal-margin unquote($important);
 }
 
 @mixin add-left-margin($important: "") {
-  margin-left: $default-horizontal-margin #{$important};
+  margin-left: $default-horizontal-margin unquote($important);
 }
 
 @mixin add-label-margin {
@@ -37,11 +37,11 @@
 }
 
 @mixin add-top-padding($important: "") {
-  padding-top: $default-vertical-padding #{$important};
+  padding-top: $default-vertical-padding unquote($important);
 }
 
 @mixin add-bottom-padding($important: "") {
-  padding-bottom: $default-vertical-padding #{$important};
+  padding-bottom: $default-vertical-padding unquote($important);
 }
 
 @mixin box-sizing {


### PR DESCRIPTION
Whitehall uses libsass for faster compilation of sass files. The libsass implementation has a string interpolation bug, spotted by @boffbowsh and avoided in https://github.com/alphagov/whitehall/commit/f15544e66ae893ec067ee99e384e82a19298cbe3

Whitehall will shortly be using this gem, meaning the sass files must be compatible with libsass. The same fixes should be applied here too.

* Replace interpolation with unquote