### PR TITLE
Fix table filtering on tables that contain multiple forms

### DIFF
--- a/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js
@@ -6,12 +6,16 @@
     that.start = function(element) {
 
       var rows = element.find('tbody tr'),
-          tableInput = element.find('.js-filter-table-input');
+          tableInput = element.find('.js-filter-table-input'),
+          filterForm;
 
       element.on('keyup change', '.js-filter-table-input', filterTableBasedOnInput);
 
       if (element.find('a.js-open-on-submit').length > 0) {
-        element.on('submit', 'form', openFirstVisibleLink);
+        filterForm = tableInput.parents('form');
+        if (filterForm && filterForm.length > 0) {
+          filterForm.on('submit', openFirstVisibleLink);
+        }
       }
 
       function filterTableBasedOnInput(event) {

--- a/spec/javascripts/spec/filterable_table.spec.js
+++ b/spec/javascripts/spec/filterable_table.spec.js
@@ -22,6 +22,13 @@ describe('A filterable table module', function() {
               <a href="/second-link" class="js-open-on-submit">another thing</a>\
             </td>\
           </tr>\
+          <tr class="third">\
+            <td>\
+              <form>\
+                <input type="submit" value="Some other form" />\
+              </form>\
+            </td>\
+          </tr>\
         </tbody>\
       </table>\
     </div>');
@@ -60,12 +67,27 @@ describe('A filterable table module', function() {
     expect(tableElement.find('.second').is(':visible')).toBe(true);
   });
 
-  describe('when the form is submitted', function() {
+  describe('when the filter form is submitted', function() {
     it('opens the first visible link', function() {
       spyOn(GOVUKAdmin, 'redirect');
       filterBy('another');
-      tableElement.find('form').trigger('submit');
+      tableElement.find('form').first().trigger('submit');
       expect(GOVUKAdmin.redirect).toHaveBeenCalledWith('/second-link');
+    });
+  });
+
+  describe('when a form other than the filter is submitted', function() {
+    it('does not open the first visible link', function() {
+      var submitted = false;
+      spyOn(GOVUKAdmin, 'redirect');
+      tableElement.find('.third form').on('submit', function(evt) {
+        evt.preventDefault();
+        submitted = true;
+      });
+
+      tableElement.find('.third form').trigger('submit');
+      expect(GOVUKAdmin.redirect).not.toHaveBeenCalled();
+      expect(submitted).toBe(true);
     });
   });
 


### PR DESCRIPTION
A form within a filterable table could not be submitted if that table used the `js-open-on-submit` feature. This was noticed in the Release app.

* Only listen to submit events on the filter form itself

cc @jamiecobbett 