### PR TITLE
Allow apps to disable Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_renderin
 `:footer_top` (optional) | Footer content before copyright text
 `:footer_version` (optional) | Text indicating the release, eg commit SHA
 `:body_end` (optional) | Just before the `</body>` tag
-`:full_width` (optional, boolean) | Expand content to edges of screen. Must be used on a per-page basis. Apps must not be full width by default.
+`:full_width` (optional, boolean) | Expand content to edges of screen.
+`:exclude_analytics` (optional, boolean) | Don’t use the default Google Analytics snippet and profile.
 `:navbar` (optional) | Custom navbar content, overrides default navbar
 
 Example navbar_items:

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -96,17 +96,19 @@
       </footer>
     </section>
     <%= yield :body_end %>
-    <% if Rails.env.production? %>
-      <script class="analytics">
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <% unless content_for?(:exclude_analytics) %>
+      <% if Rails.env.production? %>
+        <script class="analytics">
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-26179049-6', 'alphagov.co.uk');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-      </script>
+          ga('create', 'UA-26179049-6', 'alphagov.co.uk');
+          ga('set', 'anonymizeIp', true);
+          ga('send', 'pageview');
+        </script>
+      <% end %>
     <% end %>
   </body>
 </html>

--- a/spec/dummy/app/views/welcome/exclude_analytics.html.erb
+++ b/spec/dummy/app/views/welcome/exclude_analytics.html.erb
@@ -1,0 +1,4 @@
+<% content_for :exclude_analytics, true %>
+<div class="page-header">
+  <h1>exclude analytics</h1>
+</div>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,5 +2,6 @@ Dummy::Application.routes.draw do
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   root :to => 'welcome#index'
   match '/full-width' => 'welcome#full_width'
+  match '/exclude-analytics' => 'welcome#exclude_analytics'
   match '/navbar' => 'welcome#navbar'
 end

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -93,5 +93,10 @@ describe 'Layout' do
       visit '/'
       expect(page).to have_selector('script.analytics', visible: false)
     end
+
+    it 'can exclude analytics' do
+      visit '/exclude-analytics'
+      expect(page).to have_no_selector('script.analytics', visible: false)
+    end
   end
 end


### PR DESCRIPTION
Not all apps or websites using govuk_admin_template want to track to our admin analytics profile. However, having analytics enabled is a sensible default so that apps cannot forget to include tracking when created.

* Use an `exclude` option to disable analytics

This is in favour of https://github.com/alphagov/govuk_admin_template/pull/63