### PR TITLE
Allow table filtering with special characters

### DIFF
--- a/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js
@@ -20,7 +20,7 @@
 
       function filterTableBasedOnInput(event) {
         var searchString = $.trim(tableInput.val()),
-            regExp = new RegExp(searchString, 'i');
+            regExp = new RegExp(escapeStringForRegexp(searchString), 'i');
 
         rows.each(function() {
           var row = $(this);
@@ -36,6 +36,13 @@
         evt.preventDefault();
         var link = element.find('a.js-open-on-submit:visible').first();
         GOVUKAdmin.redirect(link.attr('href'));
+      }
+
+      // http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+      // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/regexp
+      // Escape ~!@#$%^&*(){}[]`/=?+\|-_;:'",<.>
+      function escapeStringForRegexp(str) {
+        return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
       }
     }
   };

--- a/spec/javascripts/spec/filterable_table.spec.js
+++ b/spec/javascripts/spec/filterable_table.spec.js
@@ -19,7 +19,7 @@ describe('A filterable table module', function() {
           </tr>\
           <tr class="second">\
             <td>\
-              <a href="/second-link" class="js-open-on-submit">another thing</a>\
+              <a href="/second-link" class="js-open-on-submit">[another thing (^lovely$)]</a>\
             </td>\
           </tr>\
           <tr class="third">\
@@ -27,6 +27,7 @@ describe('A filterable table module', function() {
               <form>\
                 <input type="submit" value="Some other form" />\
               </form>\
+              ~!@#$%^&*(){}[]`/=?+|-_;:\'",<.>\
             </td>\
           </tr>\
         </tbody>\
@@ -58,6 +59,25 @@ describe('A filterable table module', function() {
     filterBy('not a thing');
     expect(tableElement.find('.first').is(':visible')).toBe(false);
     expect(tableElement.find('.second').is(':visible')).toBe(false);
+  });
+
+  it('filters the table based on input even when containing regexp characters', function() {
+    filterBy('[another');
+    expect(tableElement.find('.first').is(':visible')).toBe(false);
+    expect(tableElement.find('.second').is(':visible')).toBe(true);
+
+    filterBy('^lovely');
+    expect(tableElement.find('.first').is(':visible')).toBe(false);
+    expect(tableElement.find('.second').is(':visible')).toBe(true);
+
+    filterBy('lovely$');
+    expect(tableElement.find('.first').is(':visible')).toBe(false);
+    expect(tableElement.find('.second').is(':visible')).toBe(true);
+
+    filterBy('~!@#$%^&*(){}[]`/=?+|-_;:\'",<.>');
+    expect(tableElement.find('.first').is(':visible')).toBe(false);
+    expect(tableElement.find('.second').is(':visible')).toBe(false);
+    expect(tableElement.find('.third').is(':visible')).toBe(true);
   });
 
   it('shows all rows when no input is entered', function() {


### PR DESCRIPTION
RegExp characters must be escaped before the search RegExp object is created otherwise an error is thrown.

Escape characters based on:
https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/regexp
http://stackoverflow.com/questions/3446170/