### PR TITLE
Improve inline form controls in IE7

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/bootstrap-ie7.scss
+++ b/app/assets/stylesheets/govuk_admin_template/bootstrap-ie7.scss
@@ -209,6 +209,14 @@ textarea.form-control {
   padding-right: 0;
 }
 
+/* Fix inline-block on inline forms
+   Most commonly used on date select fields */
+.form-inline .form-control {
+  display: inline-block;
+  zoom: 1;
+  display: inline;
+}
+
 .container,
 .container-fluid {
   zoom: 1;


### PR DESCRIPTION
`inline-block` needs to be reset to `display: inline` so that it displays correctly in IE7.

Fixes:
![screen shot 2015-07-28 at 17 37 41](https://cloud.githubusercontent.com/assets/319055/8937296/6207a378-354f-11e5-9876-7290f636c8fe.png)


https://trello.com/c/kwHqpt7U/