### PR TITLE
Port cookie functions from govuk_template

### DIFF
--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -152,6 +152,9 @@
       date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));
       cookieString = cookieString + "; expires=" + date.toGMTString();
     }
+    if (options.domain) {
+      cookieString = cookieString + "; domain=" + options.domain;
+    }
     if (document.location.protocol == 'https:'){
       cookieString = cookieString + "; Secure";
     }

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -111,12 +111,66 @@
       }
     }
 
-    // Useful for debugging:
-    // console.log(eventAnalytics);
-
     if (typeof root.ga === "function") {
       root.ga('send', eventAnalytics);
     }
   }
+
+  /*
+    Cookie methods
+    ==============
+    Usage:
+
+      Setting a cookie:
+      GOVUKAdmin.cookie('hobnob', 'tasty', { days: 30 });
+
+      Reading a cookie:
+      GOVUKAdmin.cookie('hobnob');
+
+      Deleting a cookie:
+      GOVUKAdmin.cookie('hobnob', null);
+  */
+  GOVUKAdmin.cookie = function(name, value, options) {
+    if(typeof value !== 'undefined'){
+      if(value === false || value === null) {
+        return GOVUKAdmin.setCookie(name, '', { days: -1 });
+      } else {
+        return GOVUKAdmin.setCookie(name, value, options);
+      }
+    } else {
+      return GOVUKAdmin.getCookie(name);
+    }
+  };
+
+  GOVUKAdmin.setCookie = function(name, value, options) {
+    if (typeof options === 'undefined') {
+      options = {};
+    }
+    var cookieString = name + "=" + value + "; path=/";
+    if (options.days) {
+      var date = new Date();
+      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));
+      cookieString = cookieString + "; expires=" + date.toGMTString();
+    }
+    if (document.location.protocol == 'https:'){
+      cookieString = cookieString + "; Secure";
+    }
+    document.cookie = cookieString;
+  };
+
+  GOVUKAdmin.getCookie = function(name) {
+    var nameEQ = name + "=";
+    var cookies = document.cookie.split(';');
+    for(var i = 0, len = cookies.length; i < len; i++) {
+      var cookie = cookies[i];
+      while (cookie.charAt(0) == ' ') {
+        cookie = cookie.substring(1, cookie.length);
+      }
+      if (cookie.indexOf(nameEQ) === 0) {
+        return decodeURIComponent(cookie.substring(nameEQ.length));
+      }
+    }
+    return null;
+  };
 
 })(jQuery, window);

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -32,6 +32,26 @@ describe('A GOVUKAdmin app', function() {
     expect(GOVUKAdmin.find(container)[1]).toMatch(container);
   });
 
+  describe('when manipulating cookies', function() {
+    it('can set, retrieve and delete a cookie', function() {
+      GOVUKAdmin.cookie('name', 'value');
+      expect(GOVUKAdmin.cookie('name')).toBe('value');
+      expect(document.cookie).toBe('name=value');
+
+      GOVUKAdmin.cookie('name', null);
+      expect(document.cookie).toBe('');
+      expect(GOVUKAdmin.cookie('name')).toBe(null);
+    });
+
+    it('can set an expires on a cookie', function() {
+      GOVUKAdmin.cookie('expiring', 'cookie', {days: 5});
+      expect(GOVUKAdmin.cookie('expiring')).toBe('cookie');
+      expect(document.cookie).toBe('expiring=cookie');
+      
+      GOVUKAdmin.cookie('expiring', null);
+    });
+  });
+
   describe('when a module exists', function() {
 
     var callback;


### PR DESCRIPTION
* Allow admin apps to easily set, retrieve and delete cookies.
* Add option to specify the cookie’s domain (eg per app, or across apps)

Two immediate use cases will be:
* A cross-app cookie for dismissing an "upgrade your browser" message (https://trello.com/c/k0lQ9PzQ/77-display-unsupported-browser-warning-message-for-publishing-tools-small)
* Adding login attempt counts to sign on to warn about account locks