### PR TITLE
Enable sendBeacon for all admin analytics events

### DIFF
--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -90,8 +90,11 @@
 
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
     // Default category to the page an event occurs on
+    // Uses sendBeacon for all events
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
     var eventAnalytics = {
           hitType: 'event',
+          transport: 'beacon',
           eventCategory: root.location.pathname,
           eventAction: action
         };

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -47,7 +47,7 @@ describe('A GOVUKAdmin app', function() {
       GOVUKAdmin.cookie('expiring', 'cookie', {days: 5});
       expect(GOVUKAdmin.cookie('expiring')).toBe('cookie');
       expect(document.cookie).toBe('expiring=cookie');
-      
+
       GOVUKAdmin.cookie('expiring', null);
     });
   });
@@ -140,14 +140,25 @@ describe('A GOVUKAdmin app', function() {
     it('sends them to Google Analytics', function() {
       GOVUKAdmin.trackEvent('action', 'label');
       expect(window.ga.calls.mostRecent().args).toEqual(
-        ['send', {hitType: 'event', eventCategory: '/', eventAction: 'action', eventLabel: 'label'}]
+        ['send', {
+          hitType: 'event',
+          eventCategory: '/',
+          eventAction: 'action',
+          eventLabel: 'label',
+          transport: 'beacon'
+        }]
       );
     });
 
     it('label is optional', function() {
       GOVUKAdmin.trackEvent('action');
       expect(window.ga.calls.mostRecent().args).toEqual(
-        ['send', {hitType: 'event', eventCategory: '/', eventAction: 'action'}]
+        ['send', {
+          hitType: 'event',
+          eventCategory: '/',
+          eventAction: 'action',
+          transport: 'beacon'
+        }]
       );
     });
 


### PR DESCRIPTION
In some situations we will be tracking events that are triggered just before the page unloads, in these situations we will need sendBeacon.

Enable this for all events so the implementor doesn’t need to consider the nature of the event they’re creating. There’s no known downside to this approach.

https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport

Needed as part of:
https://trello.com/c/k5F2wDcQ/151-add-google-analytics-tracking-to-2sv-user-journeys-pt-1-medium