### PR TITLE
Module to track button presses in GA

### DIFF
--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -104,3 +104,4 @@ confirm.js | `Confirm` | `confirm` | Show a [window.confirm](https://developer.m
 filterable_table.js | `FilterableTable` | `filterable-table` | Filter the contents of a table, showing only matching rows
 fixed_table_header.js | `FixedTableHeader` | `fixed-table-header` | Fix the `<thead>` portion of a table when scrolling offscreen
 toggle.js | `Toggle` | `toggle` | A simple toggle
+track_click.js | `TrackClick` | `track-click` | Track button clicks in Google Anayltics using `sendBeacon`

--- a/app/assets/javascripts/govuk-admin-template/modules/track_click.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/track_click.js
@@ -1,0 +1,19 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackClick = function() {
+    var that = this;
+
+    that.start = function(container) {
+      var trackClick = function() {
+        var action = container.data("track-action") || "button-pressed",
+            label = $(this).data("track-label") || $(this).text();
+
+        GOVUKAdmin.trackEvent(action, label);
+      };
+
+      container.on("click", ".js-track", trackClick);
+    }
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -551,3 +551,40 @@
   </div>
 </div>
 <hr>
+
+<h2>Analytics</h2>
+<div class="row">
+  <div class="col-md-6">
+    <h3>Auto Track Events</h3>
+    <p>Adding this module to a page will cause an event to be sent to Google Analytics with
+      a specified action, label and value</p>
+  </div>
+  <div class="col-md-6">
+    <pre class="add-top-margin">&lt;div class=&quot;alert-success&quot;
+     data-module=&quot;auto-track-event&quot;
+     data-track-action=&quot;alert-success&quot;
+     data-track-label=&quot;Logged in successfully&quot;&gt;
+  Logged in successfully
+&lt;/div&gt;</pre>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <h3>Track Click</h3>
+    <p>This module is intended as an easy way to track individual button/link
+    clicks as events in Google Analytics. Groups of buttons may end up
+    redirecting to the same place, meaning they’re not trackable via URLs
+    in GA. This will use the sendBeacon functionality to fire off an event
+    once the button has been clicked and during navigation.</p>
+    <p>The module should be added to the container of the buttons, where the
+    GA action can be changed from the default of <code>button-pressed</code> using the
+    <code>data-track-action</code> attribute. The label defaults to the link/button
+    text, but can be overridden with <code>data-track-label</code>.</p>
+  </div>
+  <div class="col-md-6">
+    <pre class="add-top-margin">&lt;div data-module=&quot;track-click&quot; data-track-action=&quot;dialog-buttons&quot;&gt;
+  &lt;button class=&quot;js-track&quot;&gt;Yes&lt;/button&gt;
+  &lt;a href=&quot;#&quot; class=&quot;js-track&quot; data-track-label=&quot;No&quot;&gt;Get me out&lt;/a&gt;
+&lt;/div&gt;</pre>
+  </div>
+</div>

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -108,6 +108,10 @@
           ga('set', 'anonymizeIp', true);
           ga('send', 'pageview');
         </script>
+      <% else %>
+        <script>
+          if (console) {window.ga = function() {console.log.apply(console, arguments);};}
+        </script>
       <% end %>
     <% end %>
   </body>

--- a/spec/javascripts/spec/track_click.spec.js
+++ b/spec/javascripts/spec/track_click.spec.js
@@ -1,0 +1,67 @@
+describe('A click tracker', function() {
+  "use strict";
+
+  var root = window,
+      tracker,
+      element;
+
+  beforeEach(function() {
+    tracker = new GOVUKAdmin.Modules.TrackClick();
+  });
+
+  describe('with defaults', function() {
+    beforeEach(function() {
+      element = $('\
+        <div>\
+          <a class="foo js-track">Foo</a>\
+          <a class="bar">Bar</a>\
+          <button class="js-track">Qux</button>\
+        </div>\
+      ');
+    });
+
+    it('tracks links with default action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("a.foo").click();
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Foo');
+    });
+
+    it('tracks buttons with default action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("button").click();
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Qux');
+    });
+
+    it('does not track until clicked', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      expect(GOVUKAdmin.trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not track if not enabled', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("a.bar").click();
+      expect(GOVUKAdmin.trackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with overrides specified', function(){
+    beforeEach(function() {
+      element = $('\
+        <div data-track-action="a-press">\
+          <a class="js-track" data-track-label="bar">Foo</a>\
+        </div>\
+      ');
+    });
+
+    it('tracks with supplied action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("a").click();
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('a-press', 'bar');
+    });
+  });
+});


### PR DESCRIPTION
This module is intended as an easy way to track individual button/link
clicks as events in Google Analytics. Groups of buttons may end up
redirecting to the same place, meaning they’re not trackable via URLs
in GA. This will use the sendBeacon functionality to fire off an event
once the button has been clicked and during navigation.

The module should be added to the container of the buttons, where the
GA action can be changed from the default of `button-pressed` using the
`data-track-action` attribute. The label defaults to the link/button
text, but can be overridden with `data-track-label`.

/cc @fofr 

Not sure where best to document the behaviour of this module and the available options?