### PR TITLE
Prevent GA shim output in test / CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Development
+
+* Prevent GA shim output in test / CI
+
 # 3.3.0
 
 * Add track-click module for Analytics tracking of button clicks

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -108,7 +108,7 @@
           ga('set', 'anonymizeIp', true);
           ga('send', 'pageview');
         </script>
-      <% else %>
+      <% elsif Rails.env.development? %>
         <script>
           if (console) {window.ga = function() {console.log.apply(console, arguments);};}
         </script>


### PR DESCRIPTION
This was causing lots of `send [object Object]` being output for apps
in CI. Change to only run in development mode, not test.

/cc @fofr 