### PR TITLE
Correctly start modules when they are defined on a container

### DIFF
--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -13,10 +13,9 @@
 
     modules = container.find(moduleSelector);
 
-    // Include container if it matches pattern, as that could
-    // be a module too
+    // Container could be a module too
     if (container.is(moduleSelector)) {
-      modules.push(container);
+      modules = modules.add(container);
     }
 
     return modules;

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -9,7 +9,7 @@ describe('A GOVUKAdmin app', function() {
     $('body').append(module);
 
     expect(GOVUKAdmin.find().length).toBe(1);
-    expect(GOVUKAdmin.find()[0]).toMatch(module);
+    expect(GOVUKAdmin.find().eq(0).data('module')).toBe('a-module');
 
     module.remove();
   });
@@ -20,7 +20,7 @@ describe('A GOVUKAdmin app', function() {
         container = $('<div></div>').append(module);
 
     expect(GOVUKAdmin.find(container).length).toBe(1);
-    expect(GOVUKAdmin.find(container)[0]).toMatch(module);
+    expect(GOVUKAdmin.find(container).eq(0).data('module')).toBe('a-module');
   });
 
   it('finds modules that are a container', function() {
@@ -29,7 +29,8 @@ describe('A GOVUKAdmin app', function() {
         container = $('<div data-module="container-module"></div>').append(module);
 
     expect(GOVUKAdmin.find(container).length).toBe(2);
-    expect(GOVUKAdmin.find(container)[1]).toMatch(container);
+    expect(GOVUKAdmin.find(container).eq(0).data('module')).toBe('container-module');
+    expect(GOVUKAdmin.find(container).eq(1).data('module')).toBe('a-module');
   });
 
   describe('when manipulating cookies', function() {
@@ -85,7 +86,7 @@ describe('A GOVUKAdmin app', function() {
       GOVUKAdmin.start(container);
 
       var args = callback.calls.argsFor(0);
-      expect(args[0]).toMatch(module);
+      expect(args[0].is('div[data-module="test-alert-module"]')).toBe(true);
     });
 
     it('starts all modules that are on the page', function() {


### PR DESCRIPTION
The tests contained a deficiency that was revealed when porting them to `govuk_frontend_toolkit`. The existing module assertions used `toMatch` on HTML objects which gave false positives because of shallow comparisons.

Instead assert that the jQuery object containers the HTML we expect.

This unveiled a failing test which has also been fixed. When the `data-module` was passed in on a container to the `start` method, that module wouldn't be correctly started. Instead of using `push` the jQuery collection needs to be manipulated with `add`.