### PR TITLE
Version 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.2
+
+* Fix module starting when the module is defined on the container passed into `GOVUKAdmin.start` https://github.com/alphagov/govuk_admin_template/pull/98
+
 # 3.3.1
 
 * Prevent GA shim output in test / CI

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "3.3.1"
+  VERSION = "3.3.2"
 end


### PR DESCRIPTION
Fix module starting when the module is defined on the container passed into `GOVUKAdmin.start` https://github.com/alphagov/govuk_admin_template/pull/98