### PR TITLE
Add optional signout element to nav bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ The gem source includes a [dummy app](spec/dummy) configured to behave like an a
 
 For Javascript usage, available modules and writing modules, see the [Javascript guide](JAVASCRIPT.md).
 
+### Configuration
+
+You can configure the gem with a config block in an initializer:
+
+```ruby
+# app/initializers/govuk_admin_template.rb
+GovukAdminTemplate.configure do |c|
+  c.app_title = "My Publisher"
+end
+```
+
 ### Content blocks
 
 The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_rendering.html#using-nested-layouts) for customisation.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can configure the gem with a config block in an initializer:
 # app/initializers/govuk_admin_template.rb
 GovukAdminTemplate.configure do |c|
   c.app_title = "My Publisher"
+  c.show_signout = true
 end
 ```
 

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -66,13 +66,21 @@
               </div>
             <% end %>
           </div>
-          <% if content_for?(:navbar_right) || content_for?(:navbar_items) %>
+          <% if GovukAdminTemplate::Config.show_signout || content_for?(:navbar_right) || content_for?(:navbar_items) %>
             <nav role="navigation" class="collapse navbar-collapse">
               <% if content_for?(:navbar_items) %>
                 <ul class="nav navbar-nav">
                   <%= yield :navbar_items %>
                 </ul>
               <% end %>
+
+              <% if GovukAdminTemplate::Config.show_signout %>
+                <div class="navbar-text pull-right">
+                  <%= link_to current_user.name, Plek.current.find('signon') %>
+                  &bull; <%= link_to 'Sign out', '/auth/gds/sign_out' %>
+                </div>
+              <% end %>
+
               <% if content_for?(:navbar_right) %>
                 <div class="navbar-text pull-right">
                   <%= yield :navbar_right %>

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -2,6 +2,7 @@
   environment_style = GovukAdminTemplate.environment_style
   environment_label = GovukAdminTemplate.environment_label
   app_home_path = content_for?(:app_home_path) ? yield(:app_home_path) : root_path
+  app_title = content_for?(:app_title) ? yield(:app_title) : GovukAdminTemplate::Config.app_title
 %>
 <!DOCTYPE html>
 <!--[if lte IE 7]><html class="no-js lte-ie7" lang="en"><![endif]-->
@@ -9,7 +10,7 @@
 <!--[if gt IE 8]><!--><html class="no-js" lang="en"><!--<![endif]-->
   <head>
     <meta charset="utf-8">
-    <title><%= content_for?(:page_title) ? yield(:page_title) : GovukAdminTemplate::Config.app_title %></title>
+    <title><%= content_for?(:page_title) ? yield(:page_title) : app_title %></title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>(function(d){d.className=d.className.replace(/^no-js\b/,'js');}(document.documentElement));</script>
@@ -59,7 +60,7 @@
                 <span class="icon-bar"></span>
               </a>
             <% end %>
-            <%= link_to content_for?(:app_title) ? yield(:app_title) : "GOV.UK", app_home_path, :class => 'navbar-brand' %>
+            <%= link_to app_title, app_home_path, :class => 'navbar-brand' %>
             <% if environment_label %>
               <div class="environment-label">
                 <%= environment_label %>

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -9,7 +9,7 @@
 <!--[if gt IE 8]><!--><html class="no-js" lang="en"><!--<![endif]-->
   <head>
     <meta charset="utf-8">
-    <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK" %></title>
+    <title><%= content_for?(:page_title) ? yield(:page_title) : GovukAdminTemplate::Config.app_title %></title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>(function(d){d.className=d.className.replace(/^no-js\b/,'js');}(document.documentElement));</script>

--- a/lib/govuk_admin_template.rb
+++ b/lib/govuk_admin_template.rb
@@ -1,5 +1,6 @@
 require "govuk_admin_template/version"
 require "govuk_admin_template/engine"
+require "govuk_admin_template/config"
 
 module GovukAdminTemplate
   mattr_accessor :environment_style, :environment_label

--- a/lib/govuk_admin_template/config.rb
+++ b/lib/govuk_admin_template/config.rb
@@ -1,0 +1,11 @@
+module GovukAdminTemplate
+  def self.configure
+    yield(Config)
+  end
+
+  module Config
+    # Name of your application
+    mattr_accessor :app_title
+    @@app_title = "GOV.UK"
+  end
+end

--- a/lib/govuk_admin_template/config.rb
+++ b/lib/govuk_admin_template/config.rb
@@ -7,5 +7,9 @@ module GovukAdminTemplate
     # Name of your application
     mattr_accessor :app_title
     @@app_title = "GOV.UK"
+
+    # Show username and signout link in the top right corner
+    # Default: false
+    mattr_accessor :show_signout
   end
 end

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  # Make this dummy app behave like gds-sso is included.
+  def current_user
+    OpenStruct.new(name: 'A Test User')
+  end
 end

--- a/spec/dummy/app/models/plek.rb
+++ b/spec/dummy/app/models/plek.rb
@@ -1,0 +1,10 @@
+# Dummy Plek so we don't have to add the gem to this dummy app.
+class Plek
+  def self.current
+    new
+  end
+
+  def find(*)
+    '/signon-url'
+  end
+end

--- a/spec/dummy/config/initializers/govuk_admin_template.rb
+++ b/spec/dummy/config/initializers/govuk_admin_template.rb
@@ -1,0 +1,4 @@
+GovukAdminTemplate.configure do |c|
+  c.app_title = "My Publisher"
+  c.show_signout = true
+end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe GovukAdminTemplate::Config do
+  describe "#configure" do
+    it "configures the application" do
+      GovukAdminTemplate.configure do |config|
+        config.app_title = "My Publisher"
+      end
+
+      expect(GovukAdminTemplate::Config.app_title).to eql("My Publisher")
+    end
+  end
+end


### PR DESCRIPTION
Setting `config.show_signout` will make the current username and signout link appear in the top right corner. This is a common interface element used in many apps like collections-publisher and search-admin.

It is still opt-in to prevent apps from having to upgrade.

To make the dummy app work, we've had to add a fake `current_user` method and a fake `Plek` class.

The method is "enabled" in the readme config, so that new apps use this config.

It looks like this in the dummy app:

![screen shot 2015-11-17 at 11 41 43](https://cloud.githubusercontent.com/assets/233676/11210458/398ed140-8d20-11e5-9e72-18ae28328ddc.png)