### PR TITLE
Upgrade dummy-app to Rails 4.1

### DIFF
--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency 'rails', '>= 3.2.0'
+  gem.add_dependency 'rails', '>= 4.1.0'
   gem.add_dependency 'bootstrap-sass', '~> 3.3.3'
-  gem.add_dependency 'jquery-rails', '~> 3.1.3'
+  gem.add_dependency 'jquery-rails', '~> 4.0.0'
 
-  gem.add_development_dependency 'sass-rails', '3.2.6'
+  gem.add_development_dependency 'sass-rails', '5.0.4'
   gem.add_development_dependency 'rspec-rails', '2.14.2'
   gem.add_development_dependency 'capybara', '2.4.4'
   gem.add_development_dependency 'gem_publisher', '1.3.1'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -3,7 +3,6 @@ require File.expand_path('../boot', __FILE__)
 # Pick the frameworks you want:
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "active_resource/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
@@ -48,5 +47,7 @@ module Dummy
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    config.secret_key_base = SecureRandom.hex
   end
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,4 +1,6 @@
 Dummy::Application.configure do
+  config.eager_load = false
+
   # Settings specified here will take precedence over those in config/application.rb
 
   # In the development environment your application's code is reloaded on

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -1,4 +1,6 @@
 Dummy::Application.configure do
+  config.eager_load = true
+
   # Settings specified here will take precedence over those in config/application.rb
 
   # Code is not reloaded between requests
@@ -9,7 +11,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,4 +1,6 @@
 Dummy::Application.configure do
+  config.eager_load = false
+
   # Settings specified here will take precedence over those in config/application.rb
 
   # The test environment is used exclusively to run your application's
@@ -8,7 +10,7 @@ Dummy::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Log error messages when you accidentally call methods on nil

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,7 +1,7 @@
 Dummy::Application.routes.draw do
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   root :to => 'welcome#index'
-  match '/full-width' => 'welcome#full_width'
-  match '/exclude-analytics' => 'welcome#exclude_analytics'
-  match '/navbar' => 'welcome#navbar'
+  get '/full-width' => 'welcome#full_width'
+  get '/exclude-analytics' => 'welcome#exclude_analytics'
+  get '/navbar' => 'welcome#navbar'
 end


### PR DESCRIPTION
This will allow us to use new 4.1's new features, like `add_flash_types` (for #103).

Fixes #87.

Updated to 4.1 because most apps use that or a higher version ([list of apps and versions](https://docs.google.com/spreadsheets/d/1FJmr39c9eXgpA-qHUU6GAbbJrnenc0P7JcyY2NB9PgU/edit#gid=1480786499)).