### PR TITLE
Make flashes work on Rails 4

### DIFF
--- a/lib/govuk_admin_template/view_helpers.rb
+++ b/lib/govuk_admin_template/view_helpers.rb
@@ -4,7 +4,7 @@ module GovukAdminTemplate
       html = []
 
       flash.each do |type, message|
-        next unless type.in?(%i[success info warning danger])
+        next unless type.to_sym.in?(%i[success info warning danger])
         html << content_tag(:div, message, class: "alert alert-#{type}")
       end
 

--- a/spec/dummy/app/controllers/welcome_controller.rb
+++ b/spec/dummy/app/controllers/welcome_controller.rb
@@ -1,6 +1,6 @@
 class WelcomeController < ApplicationController
   def with_flashes
-    %i[success info warning danger].each do |type|
+    %w[success info warning danger].each do |type|
       flash[type] = "I am an alert with type #{type}"
     end
 


### PR DESCRIPTION
Rails 4.2 changed the keys in `flash` from symbols to keys, so this code won't work in 4.2.X.

More info: https://github.com/rails/rails/commit/a668beffd64106a1e1fedb71cc25eaaa11baf0c1