### PR TITLE
Pin bootstrap-sass

### DIFF
--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'rails', '>= 3.2.0'
-  gem.add_dependency 'bootstrap-sass', '~> 3.3.3'
+  gem.add_dependency 'bootstrap-sass', '3.3.5'
   gem.add_dependency 'jquery-rails', '~> 3.1.3'
 
   gem.add_development_dependency 'sass-rails', '3.2.6'


### PR DESCRIPTION
Gem `bootstrap-sass` 3.3.6 is not compatible with this gem.