### PR TITLE
Improve default indicator styles

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_navbar.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_navbar.scss
@@ -77,7 +77,7 @@ header .navbar-header {
    ========================================================================== */
 
 .environment-indicator {
-  border-bottom: 5px solid #000;
+  border-bottom: 5px solid #999;
 }
 
 .environment-production .environment-indicator {
@@ -93,7 +93,8 @@ header .navbar-header {
 }
 
 .environment-label {
-  background: #333;
+  background: #fff;
+  color: #333;
   padding: 3px 5px;
   border-radius: 3px;
   font-weight: bold;


### PR DESCRIPTION
Currently, if an application is told to display an environment indicator for an environment it doesn't understand it will show up as a dark grey box with a slightly longer header.

This commit changes the default colours so that it's more obvious that this is an unstyled environment.

Nitpicking of colours is welcomed, I pulled them out of thin air.

## Before

![screen shot 2015-11-30 at 16 58 25](https://cloud.githubusercontent.com/assets/121219/11478329/30a8374c-9784-11e5-9b99-f1a1f9835a62.png)

## After

![screen shot 2015-11-30 at 17 00 08](https://cloud.githubusercontent.com/assets/121219/11478338/39804378-9784-11e5-99bc-4914994d9d38.png)

