### PR TITLE
Add govspeak help

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template.scss
+++ b/app/assets/stylesheets/govuk_admin_template.scss
@@ -13,3 +13,4 @@
 @import 'govuk_admin_template/navbar';
 @import 'govuk_admin_template/tables';
 @import 'govuk_admin_template/style_guide';
+@import 'govuk_admin_template/govspeak_help';

--- a/app/assets/stylesheets/govuk_admin_template/_govspeak_help.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_govspeak_help.scss
@@ -1,0 +1,9 @@
+.govspeak-help {
+  h3 {
+    font-size: 19px;
+    margin-top: 0;
+  }
+  a {
+    cursor: pointer;
+  }
+}

--- a/app/views/govuk_admin_template/_govspeak_help.html.erb
+++ b/app/views/govuk_admin_template/_govspeak_help.html.erb
@@ -1,0 +1,209 @@
+<div class="govspeak-help">
+  <h2>Writing style</h2>
+  <p>For style, see the <a href="https://www.gov.uk/designprinciples/styleguide">style guide</a></p>
+
+  <h2>Formatting help</h2>
+  <%= yield :format_specific_help %>
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-headings">
+      Headings
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-headings">
+    <pre>## Top level heading - H2
+  ### Second level heading - H3
+  #### Third level heading - H4
+
+  Don't use a single # - this is H1 and is for the title only</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-links">
+      Links
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-links" style="height: auto;">
+    <p>
+      All documents created in the publisher - policies, publications, news, speeches, detailed guides etc -
+      should be linked to using absolute admin paths or full public URLs:
+    </p>
+    <pre>[an admin path](/government/admin/policies/12345)
+  [a public URL](https://www.gov.uk/government/policies/example-policy)</pre>
+
+    <p>All content created under an organisation tab - collection pages, topics, organisations, people, roles etc - should be linked to using the full, public URLs:</p>
+    <pre>[link text](https://www.gov.uk/government/topics/climate-change)</pre>
+
+    <p>For external websites, use the full URL including http://:</p>
+    <pre>[link text](http://www.example.com)</pre>
+    <p>The link will display with an external link symbol.</p>
+
+    <h4>Linking to paragraphs</h4>
+    <p>
+      If you want to link to specific paragraphs within a document, you need to mark the paragraph as linkable
+      by placing an anchor tag <strong>below</strong> the paragraph:
+    </p>
+  <pre>Stocks of some fish species are very low. For example, stocks of European Eel have declined by about 95% over the last 30 years.
+  {:#eel-decline}
+  </pre>
+
+    <p>The paragraph can then be linked to from the same document:</p>
+    <pre>[Sample link text](#eel-decline)</pre>
+
+    <p>or from another document:</p>
+    <pre>[Sample link text](https://www.gov.uk/government/policies/managing-freshwater-fisheries#eel-decline)</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-bullets">
+      Bullets
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-bullets" style="height: 0px;">
+    <pre>* item 1
+  * item 2
+    * sub-item
+    * another sub-item
+  (to indent, add 2 spaces)</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-numbered-list">
+      Numbered list
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-numbered-list" style="height: 0px;">
+    <pre>1. item 1
+  2. item 2
+  3. item 3
+    * sub-item
+    * another sub-item
+  (to indent, add 2 spaces)</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-priority-list">
+      Priority list
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-priority-list">
+    <p>
+      You can create a list which shows only the first n items (including attachments),
+      with a link to open the others, eg to show the first item:
+    </p>
+
+    <pre>$PriorityList:1
+  * item 1
+  * item 2
+  * item 3</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-legislative-list">
+      Legislative list
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-legislative-list">
+    <p>
+      For lists where you want to specify the numbering and have multiple indent levels.
+    </p>
+
+    <pre>$LegislativeList
+  * 1. Item 1
+  * 2. Item 2
+    * a) Item 2a
+    * b) Item 2b
+      * i. Item 2 b i
+      * ii. Item 2 b ii
+  * 3. Item 3
+  $EndLegislativeList
+  (to indent, add 2 spaces)</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-tables">
+      Tables
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-tables">
+    <p>Tables can be inserted by splitting your content into cells:</p>
+    <pre>| name | colour |
+  |--------|-------|
+  | apple | green |
+  | banana | yellow |</pre>
+
+  <p>You can also use a shorthand version of the markdown, which will produce exactly the same output:</p>
+    <pre>name | colour
+  -|-
+  apple | green
+  banana | yellow</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-cta">
+      Call to action
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-cta" style="height: 0px;">
+    <pre>$CTA
+  [Use the trade tariff tool to find commodity codes.](https://www.gov.uk/trade-tariff)
+  $CTA</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-acronyms">
+      Acronyms
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-acronyms">
+    <pre>*[DWP]: Department for Work and Pensions</pre>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-blockquotes">
+      Blockquotes
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-blockquotes" style="height: 0px;">
+    <pre>As the Prime Minister said:
+
+  &gt; Rule, Britannia, rule the waves.
+  &gt;
+  &gt; Britons never shall be slaves.</pre>
+    <p>The &gt; in the line space is important. If you leave it out you will get 2 separate quotes, not 1 running quote.</p>
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-addresses">
+      Addresses
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-addresses" style="height: 0px;">
+    <pre>$A
+  Address
+  Only
+  Here
+  $A</pre>
+
+  </div>
+
+  <h3>
+    <a data-toggle="collapse" data-target="#govspeak-footnotes">
+      Footnotes
+    </a>
+  </h3>
+  <div class="collapse" id="govspeak-footnotes">
+    <pre>Footnotes can be added[^1].
+
+  [^1]: And then later defined.</pre>
+    <p>
+      You can add a footnote marker to a document using [^<em>i</em>] where <em>i</em> is the footnote number or label. Each of these tags should have corresponding footnote content, defined with [^<em>i</em>]: <em>The footnote content</em>. The footnote content will always appear at the end of the document regardless of where they are in the markdown.
+    </p>
+    <p>
+      Footnote content can hold more than one paragraph by indenting the content 4 spaces:
+    </p>
+
+    <pre>[^1]:
+      This is some footnote content and is indented 4 spaces.
+
+      This paragraph is also indented, so will be considered part of the footnote content.</pre>
+</div>


### PR DESCRIPTION
Add a template that shows a cheat sheet for govspeak usage.

In `publisher` and `specialist-publisher` the cheat sheet seems to almost be copy pasted. For `service-manual-publisher` we're going to avoid this.

The help in `specialist-publisher` seems to be the newest/best, so I've copied this.

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-14-12-2015-16-16-09-jophohce.png)