### PR TITLE
Version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.0
+
+* Allow environment style and labels to be set to integration. When using integration as the environment style the custom favicon in the application must also be present. eg `favicon-preview.png` must be duplicated as `favicon-integration.png`. #102
+
 # 3.5.0
 
 * Add a govspeak help template

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "3.5.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
* Allow environment style and labels to be set to integration. When using integration as the environment style the custom favicon in the application must also be present. eg `favicon-preview.png` must be duplicated as `favicon-integration.png`. #102

cc @alexmuller 