### PR TITLE
Tweak bootstrap-sass pin and navbar logic

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -3,6 +3,7 @@
   environment_label = GovukAdminTemplate.environment_label
   app_home_path = content_for?(:app_home_path) ? yield(:app_home_path) : root_path
   app_title = content_for?(:app_title) ? yield(:app_title) : GovukAdminTemplate::Config.app_title
+  has_navbar_content = GovukAdminTemplate::Config.show_signout || content_for?(:navbar_right) || content_for?(:navbar_items)
 %>
 <!DOCTYPE html>
 <!--[if lte IE 7]><html class="no-js lte-ie7" lang="en"><![endif]-->
@@ -51,7 +52,7 @@
         add-bottom-margin" role="banner">
         <div class="<%= content_for?(:full_width) ? 'container-fluid' : 'container' %>">
           <div class="navbar-header">
-            <% if content_for?(:navbar_right) || content_for?(:navbar_items) %>
+            <% if has_navbar_content %>
               <%# Bootstrap toggle for collapsed navbar content, used at smaller widths %>
               <a class="navbar-toggle" data-toggle="collapse" data-target="header .navbar-collapse">
                 <span class="sr-only">Toggle navigation</span>
@@ -67,7 +68,7 @@
               </div>
             <% end %>
           </div>
-          <% if GovukAdminTemplate::Config.show_signout || content_for?(:navbar_right) || content_for?(:navbar_items) %>
+          <% if has_navbar_content %>
             <nav role="navigation" class="collapse navbar-collapse">
               <% if content_for?(:navbar_items) %>
                 <ul class="nav navbar-nav">

--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'rails', '>= 3.2.0'
-  gem.add_dependency 'bootstrap-sass', '3.3.5'
+  gem.add_dependency 'bootstrap-sass', '3.3.5.1'
   gem.add_dependency 'jquery-rails', '~> 3.1.3'
 
   gem.add_development_dependency 'sass-rails', '3.2.6'

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <%# blocks for govuk_admin_template %>
 <% content_for :page_title do %>page_title<% end %>
+<%# app_title can be set here or in the config %>
 <% content_for :app_title do %>GOV.UK app_title<% end %>
 <% content_for :app_home_path, govuk_admin_template_engine_path %>
 <% content_for :head do %>


### PR DESCRIPTION
* Use 3.3.5.1 rather than 3.3.5 as this contains a necessary Sass dependency fix: https://rubygems.org/gems/bootstrap-sass/versions/3.3.5.1. Pinning because bootstrap-sass has a tendency to release breaking changes in point releases.

* Move navbar logic into variable. Fixes a bug where the collapsed nav icon wouldn’t shown when there are no navbar items but there is a sign out link.