### PR TITLE
Allow the URL sent to Google Analytics to be overridden

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -120,7 +120,11 @@
 
           ga('create', 'UA-26179049-6', '<%= ENV.fetch('GOVUK_APP_DOMAIN') %>');
           ga('set', 'anonymizeIp', true);
-          ga('send', 'pageview');
+          <% if content_for?(:custom_pageview_fullpath) %>
+            GOVUKAdmin.trackPageview('<%= content_for(:custom_pageview_fullpath) %>');
+          <% else %>
+            ga('send', 'pageview');
+          <% end %>
         </script>
       <% elsif Rails.env.development? %>
         <script>

--- a/spec/dummy/app/views/welcome/custom_pageview_url.html.erb
+++ b/spec/dummy/app/views/welcome/custom_pageview_url.html.erb
@@ -1,0 +1,1 @@
+<% content_for :custom_pageview_fullpath, "/not-the-actual-url-the-user-navigated-to" %>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -3,6 +3,7 @@ Dummy::Application.routes.draw do
   root :to => 'welcome#index'
   match '/full-width' => 'welcome#full_width'
   match '/exclude-analytics' => 'welcome#exclude_analytics'
+  match '/custom-pageview-url' => 'welcome#custom_pageview_url'
   match '/navbar' => 'welcome#navbar'
   match '/with-flashes' => 'welcome#with_flashes'
 end

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -95,10 +95,12 @@ describe 'Layout' do
   end
 
   describe 'in production' do
-    before { Rails.env.stub(:production? => true) }
-    it 'includes analytics' do
+    before do
+      Rails.env.stub(:production? => true)
       ENV.stub(:fetch).with('GOVUK_APP_DOMAIN').and_return('root.gov.uk')
+    end
 
+    it 'includes analytics' do
       visit '/'
       expect(page).to have_selector('script.analytics', visible: false)
       expect(page.body).to include("'root.gov.uk'")
@@ -107,6 +109,11 @@ describe 'Layout' do
     it 'can exclude analytics' do
       visit '/exclude-analytics'
       expect(page).to have_no_selector('script.analytics', visible: false)
+    end
+
+    it 'can specify a custom pageview URL' do
+      visit '/custom-pageview-url'
+      expect(page.html).to include("GOVUKAdmin.trackPageview('/not-the-actual-url-the-user-navigated-to');")
     end
   end
 end


### PR DESCRIPTION
Useful if you want to remove any sensitive data in the URL first.