### PR TITLE
Add favicons to precompile

### DIFF
--- a/lib/govuk_admin_template/engine.rb
+++ b/lib/govuk_admin_template/engine.rb
@@ -5,6 +5,9 @@ module GovukAdminTemplate
 
     initializer 'govuk_admin_template.assets.precompile' do |app|
       app.config.assets.precompile += %w(lte-ie8.js govuk-admin-template.js govuk_admin_template/bootstrap-ie7.css)
+      app.config.assets.precompile += %w(govuk_admin_template/favicon-development.png govuk_admin_template/favicon-integration.png
+                                          govuk_admin_template/favicon-preview.png govuk_admin_template/favicon.production.png govuk_admin_template/favicon.png)
+
     end
 
     # User friendly GOV.UK date formats, based on:


### PR DESCRIPTION
This fixes the issue with sprockets-rails > 3 that requires favicon.png to be added to `Rails.application.config.assets.precompile`