### PR TITLE
Redact emails in GA events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+# Development
+
+* Redact emails from Google Analytics event labels and actions
+
 # 4.1.1
 
-* Add assets initializer to support sprockets-rails >= 3 
+* Add assets initializer to support sprockets-rails >= 3
 
 # 4.1.0
 

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -95,12 +95,12 @@
           hitType: 'event',
           transport: 'beacon',
           eventCategory: root.location.pathname,
-          eventAction: action
+          eventAction: redactEmails(action)
         };
 
     // Label is optional
     if (typeof label === "string") {
-      eventAnalytics.eventLabel = label;
+      eventAnalytics.eventLabel = redactEmails(label);
     }
 
     // Value is optional, but when used must be an
@@ -115,6 +115,10 @@
 
     if (typeof root.ga === "function") {
       root.ga('send', eventAnalytics);
+    }
+
+    function redactEmails(string) {
+      return string.replace(/\S+@\S+/g, '[email]');
     }
   }
 

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -173,5 +173,20 @@ describe('A GOVUKAdmin app', function() {
       GOVUKAdmin.trackEvent('action', 'label', 'not a number');
       expect(eventObjectFromSpy()['eventValue']).toEqual(undefined);
     });
+
+    it('redacts any email addresses accidentally passed in as actions or labels', function() {
+      GOVUKAdmin.trackEvent('this email@email.com is bad', 'and that a@a.co.uk');
+      expect(eventObjectFromSpy()['eventAction']).toEqual('this [email] is bad');
+      expect(eventObjectFromSpy()['eventLabel']).toEqual('and that [email]');
+
+      GOVUKAdmin.trackEvent('email@email.com');
+      expect(eventObjectFromSpy()['eventAction']).toEqual('[email]');
+
+      GOVUKAdmin.trackEvent('1@email.com 2@this.com 3@gov.uk 4@business.biz');
+      expect(eventObjectFromSpy()['eventAction']).toEqual('[email] [email] [email] [email]');
+
+      GOVUKAdmin.trackEvent('@something @twitterhandle sent to email@email.com @ 2pm');
+      expect(eventObjectFromSpy()['eventAction']).toEqual('@something @twitterhandle sent to [email] @ 2pm');
+    });
   });
 });


### PR DESCRIPTION
Prevent apps from accidentally sending government user’s email addresses to Google Analytics.

This was previously added on a case by case basis in app code. However some emails still made it through as it wasn’t always considered. Instead do a blanket prevention.

Based on existing Sign on approach:
https://github.com/alphagov/signonotron2/blob/ac7e56dcc84e5572ef51aa066356d32f6fcc122a/app/helpers/application_helper.rb#L31

https://trello.com/c/0SLWcJwI/337-strip-personally-identifiable-information-before-sending-to-analytics-medium