### PR TITLE
Add simple_form config in an initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ in your `spec/javascripts/support/jasmine.yml` like this:
 ```yaml
 src_files:
   - assets/govuk-admin-template.js
- ```
+```
 
 It is recommended that the style guide is also made available within your app at the route `/style-guide`. Add this to your `config/routes.rb` file:
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ GovukAdminTemplate.configure do |c|
 end
 ```
 
+### Forms
+
+Some GOV.UK admin apps use the [Simple
+Form](https://github.com/plataformatec/simple_form) library for writing form
+markup. This repo contains a standard configuration in
+`config/initializers/simple_form.rb`. Simply add `simple_form` to your Gemfile
+along with `govuk_admin_template` to automatically load this config file.
+
 ### Content blocks
 
 The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_rendering.html#using-nested-layouts) for customisation.

--- a/README.md
+++ b/README.md
@@ -105,9 +105,24 @@ end
 
 Some GOV.UK admin apps use the [Simple
 Form](https://github.com/plataformatec/simple_form) library for writing form
-markup. This repo contains a standard configuration in
-`config/initializers/simple_form.rb`. Simply add `simple_form` to your Gemfile
-along with `govuk_admin_template` to automatically load this config file.
+markup. This repo contains a recommended configuration in
+`lib/govuk_admin_template/simple_form.rb`.
+
+To use this configuration:
+
+0. Add `simple_form` to your Gemfile.
+0. Add an initializer in `config/initializers/simple_form.rb` containing the
+   following:
+
+```
+SimpleForm.setup do |config|
+  GovukAdminTemplate.setup_simple_form(config)
+end
+```
+
+This gem also provides an i18n file in `config/locales/simple_form.en.yml`.
+This removes the need for this file to be present in the host project unless
+specific customisations are required.
 
 ### Content blocks
 

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,105 @@
+# Recommended Simple Form configuration. This initializer will be loaded
+# automatically in projects that have both govuk_admin_template and
+# simple_form in their Gemfile.
+
+if defined?(SimpleForm)
+  # Use this setup block to configure all options available in SimpleForm.
+  SimpleForm.setup do |config|
+    # Wrappers are used by the form builder to generate a complete input.
+    # You can remove any component from the wrapper, change the order or
+    # even add your own to the stack.
+
+    # The options given below are used to wrap the whole input.
+    config.wrappers :default, class: :input, hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+      # Determines whether to use HTML5 (:email, :url, ...)
+      # and required attributes
+      b.use :html5
+
+      # Calculates placeholders automatically from I18n
+      # You can also pass a string as f.input placeholder: "Placeholder"
+      b.use :placeholder
+
+      ## Optional extensions
+      # They are disabled unless you pass `f.input EXTENSION_NAME => :lookup`
+      # to the input. If so, they will retrieve the values from the model
+      # if any exists. If you want to enable the lookup for any of those
+      # extensions by default, you can change `b.optional` to `b.use`.
+
+      # Calculates maxlength from length validations for string inputs
+      b.optional :maxlength
+
+      # Calculates pattern from format validations for string inputs
+      b.optional :pattern
+
+      # Calculates min and max from length validations for numeric inputs
+      b.optional :min_max
+
+      # Calculates readonly automatically from readonly attributes
+      b.optional :readonly
+
+      ## Inputs
+      b.use :label_input
+      b.use :hint,  wrap_with: { tag: :span, class: :hint }
+      b.use :error, wrap_with: { tag: :span, class: :error }
+    end
+
+    config.wrappers :bootstrap, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.use :label, class: 'control-label'
+      b.wrapper tag: 'div' do |ba|
+        ba.use :input
+        ba.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
+        ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+      end
+    end
+
+    config.wrappers :prepend, tag: 'div', class: "form-group", error_class: 'has-error' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.use :label
+      b.wrapper tag: 'div', class: 'controls' do |input|
+        input.wrapper tag: 'div', class: 'input-prepend' do |prepend|
+          prepend.use :input
+        end
+        input.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+        input.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
+      end
+    end
+
+    config.wrappers :append, tag: 'div', class: "form-group", error_class: 'has-error' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.use :label
+      b.wrapper tag: 'div', class: 'controls' do |input|
+        input.wrapper tag: 'div', class: 'input-append' do |append|
+          append.use :input
+        end
+        input.use :hint,  wrap_with: { tag: 'span', class: 'help-block' }
+        input.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
+      end
+    end
+
+    # The default wrapper to be used by the FormBuilder.
+    config.default_wrapper = :bootstrap
+
+    # Define the way to render check boxes / radio buttons with labels.
+    # Defaults to :nested for bootstrap config.
+    #   inline: input + label
+    #   nested: label > input
+    config.boolean_style = :inline
+
+    # Default class for buttons
+    config.button_class = 'btn'
+
+    # Default tag used for error notification helper.
+    config.error_notification_tag = :div
+
+    # CSS class to add for error notification helper.
+    config.error_notification_class = 'alert alert-danger'
+
+    # Tell browsers whether to use default HTML5 validations (novalidate option).
+    # Default is enabled.
+    config.browser_validations = false
+  end
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    labels:
+      defaults:
+        title: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/lib/govuk_admin_template.rb
+++ b/lib/govuk_admin_template.rb
@@ -2,6 +2,7 @@ require "govuk_admin_template/version"
 require "govuk_admin_template/engine"
 require "govuk_admin_template/config"
 require "govuk_admin_template/view_helpers"
+require "govuk_admin_template/simple_form"
 
 module GovukAdminTemplate
   mattr_accessor :environment_style, :environment_label

--- a/lib/govuk_admin_template/simple_form.rb
+++ b/lib/govuk_admin_template/simple_form.rb
@@ -1,10 +1,5 @@
-# Recommended Simple Form configuration. This initializer will be loaded
-# automatically in projects that have both govuk_admin_template and
-# simple_form in their Gemfile.
-
-if defined?(SimpleForm)
-  # Use this setup block to configure all options available in SimpleForm.
-  SimpleForm.setup do |config|
+module GovukAdminTemplate
+  def self.setup_simple_form(config)
     # Wrappers are used by the form builder to generate a complete input.
     # You can remove any component from the wrapper, change the order or
     # even add your own to the stack.


### PR DESCRIPTION
Some of our admin apps (content-tagger, for example) use the simple_form
gem. This commit adds a standard configuration and explains how it's
loaded in the README.

https://trello.com/c/fXy6rS2O/85-move-simple-form-config-into-govuk-admin-template-gem