### PR TITLE
Disable default lable text

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -11,9 +11,9 @@ en:
     error_notification:
       default_message: "Please review the problems below:"
     # Examples
-    labels:
-      defaults:
-        title: 'Password'
+    # labels:
+    #   defaults:
+    #     title: 'Password'
     #   user:
     #     new:
     #       email: 'E-mail to sign in.'


### PR DESCRIPTION
If a form input element doesn't have `label: "Label text"`, it would default to
`Password`, which might not be correct.

This commit disables a default text for input elements without an explicit
label.