### PR TITLE
Modularize the table-filter markup

### DIFF
--- a/app/views/govuk_admin_template/_table_filter.html.erb
+++ b/app/views/govuk_admin_template/_table_filter.html.erb
@@ -5,9 +5,8 @@
 %>
 <tr class="if-no-js-hide table-header-secondary">
   <td colspan="<%= colspan %>">
-    <form>
-      <label for="<%= filter_id %>" class="rm"><%= placeholder %></label>
-      <input id="<%= filter_id %>" type="text" class="form-control normal js-filter-table-input" placeholder="<%= placeholder %>">
-    </form>
+  <%=
+    render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: placeholder, filter_id: filter_id }
+  %>
   </td>
 </tr>

--- a/app/views/govuk_admin_template/_table_filter_form.html.erb
+++ b/app/views/govuk_admin_template/_table_filter_form.html.erb
@@ -1,0 +1,8 @@
+<%
+  placeholder ||= "Filter table"
+  filter_id ||= SecureRandom.uuid
+%>
+<form>
+  <label for="<%= filter_id %>" class="rm"><%= placeholder %></label>
+  <input id="<%= filter_id %>" type="text" class="form-control normal js-filter-table-input" placeholder="<%= placeholder %>">
+</form>


### PR DESCRIPTION
We want to use the table-filter function in local-links-manager, but our design requires the <form> to share a table row with another form-control.

This change makes it possible to use the table-filter in other contexts by decoupling the functionality from the table markup.