### PR TITLE
Adds disable_google_analytics setting to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ GovukAdminTemplate.configure do |c|
   c.app_title = "My Publisher"
   c.show_flash = true
   c.show_signout = true
+  c.disable_google_analytics = false
 end
 ```
 

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -4,6 +4,7 @@
   app_home_path = content_for?(:app_home_path) ? yield(:app_home_path) : root_path
   app_title = content_for?(:app_title) ? yield(:app_title) : GovukAdminTemplate::Config.app_title
   has_navbar_content = GovukAdminTemplate::Config.show_signout || content_for?(:navbar_right) || content_for?(:navbar_items)
+  disable_google_analytics = GovukAdminTemplate::Config.disable_google_analytics
 %>
 <!DOCTYPE html>
 <!--[if lte IE 7]><html class="no-js lte-ie7" lang="en"><![endif]-->
@@ -110,7 +111,7 @@
       </footer>
     </section>
     <%= yield :body_end %>
-    <% unless content_for?(:exclude_analytics) %>
+    <% unless content_for?(:exclude_analytics) || disable_google_analytics %>
       <% if Rails.env.production? %>
         <script class="analytics">
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/lib/govuk_admin_template/config.rb
+++ b/lib/govuk_admin_template/config.rb
@@ -15,5 +15,9 @@ module GovukAdminTemplate
     # Show username and signout link in the top right corner
     # Default: false
     mattr_accessor :show_signout
+
+    # Disable analytics
+    # Default: false
+    mattr_accessor :disable_google_analytics
   end
 end

--- a/spec/dummy/config/initializers/govuk_admin_template.rb
+++ b/spec/dummy/config/initializers/govuk_admin_template.rb
@@ -2,4 +2,5 @@ GovukAdminTemplate.configure do |c|
   c.app_title = "My Publisher"
   c.show_flash = true
   c.show_signout = true
+  c.disable_google_analytics = false
 end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -5,9 +5,11 @@ describe GovukAdminTemplate::Config do
     it "configures the application" do
       GovukAdminTemplate.configure do |config|
         config.app_title = "My Publisher"
+        config.disable_google_analytics = false
       end
 
       expect(GovukAdminTemplate::Config.app_title).to eql("My Publisher")
+      expect(GovukAdminTemplate::Config.disable_google_analytics).to eql(false)
     end
   end
 end


### PR DESCRIPTION
This will avoid the potential surprise of an application crashing when being deployed to production
because it is expecting google analytics credentials.

Enables analytics to be disabled using a config setting. The gem currently assumes that all projects
created with the govuk template want to enable google analytics. This setting will not change current projects using the gem, but will make it less opinionated about using analytics.

