### PR TITLE
Remove template based analytics exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Development
+
+* Remove `exclude_analytics` content block from template
+* Add `disable_google_analytics` to config
+
 # 4.4.2
 
 * Modularize the table-filter markup

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_renderin
 `:body_start` (optional) | Just after the `<body>` tag
 `:body_end` (optional) | Just before the `</body>` tag
 `:full_width` (optional, boolean) | Expand content to edges of screen.
-`:exclude_analytics` (optional, boolean) | Don’t use the default Google Analytics snippet and profile.
 `:navbar` (optional) | Custom navbar content, overrides default navbar
 
 Example navbar_items:

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -111,7 +111,7 @@
       </footer>
     </section>
     <%= yield :body_end %>
-    <% unless content_for?(:exclude_analytics) || disable_google_analytics %>
+    <% unless disable_google_analytics %>
       <% if Rails.env.production? %>
         <script class="analytics">
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/spec/dummy/app/views/welcome/exclude_analytics.html.erb
+++ b/spec/dummy/app/views/welcome/exclude_analytics.html.erb
@@ -1,4 +1,0 @@
-<% content_for :exclude_analytics, true %>
-<div class="page-header">
-  <h1>exclude analytics</h1>
-</div>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,7 +2,6 @@ Dummy::Application.routes.draw do
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   root :to => 'welcome#index'
   get '/full-width' => 'welcome#full_width'
-  get '/exclude-analytics' => 'welcome#exclude_analytics'
   get '/custom-pageview-url' => 'welcome#custom_pageview_url'
   get '/navbar' => 'welcome#navbar'
   get '/with-flashes' => 'welcome#with_flashes'

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -106,11 +106,6 @@ describe 'Layout' do
       expect(page.body).to include("'root.gov.uk'")
     end
 
-    it 'can exclude analytics' do
-      visit '/exclude-analytics'
-      expect(page).to have_no_selector('script.analytics', visible: false)
-    end
-
     it 'can specify a custom pageview URL' do
       visit '/custom-pageview-url'
       expect(page.html).to include("GOVUKAdmin.trackPageview('/not-the-actual-url-the-user-navigated-to');")


### PR DESCRIPTION
It is better to use the config provided in https://github.com/alphagov/govuk_admin_template/pull/136
Set `disable_google_analytics` to true in the config instead.

This will be versioned as a breaking change.