### PR TITLE
Version 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Development
+# 5.0.0
 
-* Remove `exclude_analytics` content block from template
+* Remove `exclude_analytics` content block from template. References to `exclude_analytics` should be removed and replaced with the following config flag.
 * Add `disable_google_analytics` to config
 
 # 4.4.2

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "4.4.2"
+  VERSION = "5.0.0"
 end


### PR DESCRIPTION
Includes a breaking change. References to `exclude_analytics` should be removed and replaced with a config flag.

* Remove `exclude_analytics` content block from template
* Add `disable_google_analytics` to config