### PR TITLE
Extends analytics

### DIFF
--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -85,16 +85,23 @@
 
   // Google Analytics event tracking
   // Label and value are optional
-  GOVUKAdmin.trackEvent = function(action, label, value) {
-
+  GOVUKAdmin.trackEvent = function(action, label, value, category) {
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
     // Default category to the page an event occurs on
     // Uses sendBeacon for all events
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
+
+    // Category is optional, but when used must be
+    // either a string such as "userInteraction:LLM"
+    // or the path name
+    if (typeof category === 'undefined') {
+      category = root.location.pathname;
+    }
+
     var eventAnalytics = {
           hitType: 'event',
           transport: 'beacon',
-          eventCategory: root.location.pathname,
+          eventCategory: category,
           eventAction: redactEmails(action)
         };
 

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -129,6 +129,16 @@
     }
   }
 
+  GOVUKAdmin.setDimension = function(index, value) {
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
+    // The custom dimension index must be configured within the
+    // Universal Analytics profile
+
+    if (typeof root.ga === "function") {
+      root.ga('set', 'dimension' + index, String(value));
+    }
+  }
+
   /*
     Cookie methods
     ==============

--- a/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js
@@ -6,9 +6,10 @@
     that.start = function(element) {
       var action = element.data('track-action'),
           label = element.data('track-label'),
-          value = element.data('track-value');
+          value = element.data('track-value'),
+          category = element.data('track-category');
 
-      GOVUKAdmin.trackEvent(action, label, value);
+      GOVUKAdmin.trackEvent(action, label, value, category);
     }
   };
 

--- a/app/assets/javascripts/govuk-admin-template/modules/track_click.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/track_click.js
@@ -7,9 +7,11 @@
     that.start = function(container) {
       var trackClick = function() {
         var action = container.data("track-action") || "button-pressed",
-            label = $(this).data("track-label") || $(this).text();
+            label = $(this).data("track-label") || $(this).text(),
+            value = $(this).data('track-value'),
+            category = container.data('track-category');
 
-        GOVUKAdmin.trackEvent(action, label);
+        GOVUKAdmin.trackEvent(action, label, value, category);
       };
 
       container.on("click", ".js-track", trackClick);

--- a/app/assets/javascripts/govuk-admin-template/modules/track_submit.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/track_submit.js
@@ -1,0 +1,21 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackSubmit = function() {
+    var that = this;
+
+    that.start = function(container) {
+      var action = container.data('track-action'),
+        label = container.data('track-label'),
+        value = container.data('track-value'),
+        category = container.data('track-category');
+
+      var trackSubmit = function() {
+        GOVUKAdmin.trackEvent(action, label, value, category);
+      };
+
+      container.on("submit", trackSubmit);
+    }
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -121,6 +121,9 @@
 
           ga('create', 'UA-26179049-6', '<%= ENV.fetch('GOVUK_APP_DOMAIN') %>');
           ga('set', 'anonymizeIp', true);
+
+          <%= content_for(:before_pageview_js) %>
+
           <% if content_for?(:custom_pageview_fullpath) %>
             GOVUKAdmin.trackPageview('<%= content_for(:custom_pageview_fullpath) %>');
           <% else %>

--- a/spec/javascripts/spec/auto_track_event.spec.js
+++ b/spec/javascripts/spec/auto_track_event.spec.js
@@ -7,7 +7,7 @@ describe('An auto event tracker', function() {
 
   beforeEach(function() {
     element = $('\
-      <div data-track-action="action" data-track-label="label" data-track-value="10">\
+      <div data-track-action="action" data-track-label="label" data-track-value="10" data-track-category="category">\
       </div>\
     ');
 
@@ -17,6 +17,6 @@ describe('An auto event tracker', function() {
   it('tracks events on start', function() {
     spyOn(root.GOVUKAdmin, 'trackEvent');
     tracker.start(element);
-    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('action', 'label', 10)
+    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('action', 'label', 10, 'category')
   });
 });

--- a/spec/javascripts/spec/track_click.spec.js
+++ b/spec/javascripts/spec/track_click.spec.js
@@ -24,14 +24,15 @@ describe('A click tracker', function() {
       spyOn(root.GOVUKAdmin, 'trackEvent');
       tracker.start(element);
       element.find("a.foo").click();
-      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Foo');
+
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Foo', undefined, undefined);
     });
 
     it('tracks buttons with default action and label', function() {
       spyOn(root.GOVUKAdmin, 'trackEvent');
       tracker.start(element);
       element.find("button").click();
-      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Qux');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Qux', undefined, undefined);
     });
 
     it('does not track until clicked', function() {
@@ -61,7 +62,24 @@ describe('A click tracker', function() {
       spyOn(root.GOVUKAdmin, 'trackEvent');
       tracker.start(element);
       element.find("a").click();
-      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('a-press', 'bar');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('a-press', 'bar', undefined, undefined);
+    });
+  });
+
+  describe('with action, label, value and category specified', function(){
+    beforeEach(function() {
+      element = $('\
+        <div data-track-action="delete-button-click" data-track-category="userInteraction:LLM">\
+          <a class="js-track" data-track-label="delete-link">Foo</a>\
+        </div>\
+      ');
+    });
+
+    it('tracks with supplied action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("a").click();
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('delete-button-click', 'delete-link', undefined, "userInteraction:LLM");
     });
   });
 });

--- a/spec/javascripts/spec/track_submit.spec.js
+++ b/spec/javascripts/spec/track_submit.spec.js
@@ -1,0 +1,83 @@
+describe('A form submit tracker', function() {
+  "use strict";
+
+  var root = window,
+    tracker,
+    element;
+
+  beforeEach(function() {
+    tracker = new GOVUKAdmin.Modules.TrackSubmit();
+  });
+
+  describe('with defaults', function() {
+    beforeEach(function() {
+      element = $('\
+        <div \
+          data-track-action="form-submitted"\
+          data-track-label= "edit-link">\
+          <form method="post">\
+            <button type="submit">Submit</button>\
+          </form>\
+        </div>\
+      ');
+    });
+
+    it('tracks submit events with default category and action', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find('form').trigger('submit');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('form-submitted', 'edit-link', undefined, undefined);
+    });
+
+    it('does not track until submitted', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      expect(GOVUKAdmin.trackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with overrides specified', function(){
+    beforeEach(function() {
+      element = $('\
+        <div \
+          data-track-action="form-submitted"\
+          data-track-label= "edit-link"\
+          data-track-category="userInteraction:LLM">\
+          <form method="post">\
+            <button type="submit">Submit</button>\
+          </form>\
+        </div>\
+      ');
+    });
+
+    it('tracks with supplied action, label, value and category', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find('form').trigger('submit');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('form-submitted', 'edit-link', undefined, "userInteraction:LLM");
+    });
+  });
+
+  describe('with action, label, value and category specified', function(){
+    beforeEach(function() {
+      element = $('\
+        <div \
+          data-track-action="form-submitted"\
+          data-track-label= "edit-link"\
+          data-track-value= "link1"\
+          data-track-category="userInteraction:LLM">\
+          <form method="post">\
+            <button type="submit">Submit</button>\
+          </form>\
+        </div>\
+      ');
+    });
+
+    it('tracks with supplied action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find('form').trigger('submit');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('form-submitted', 'edit-link', "link1", "userInteraction:LLM");
+    });
+  });
+});


### PR DESCRIPTION
[Trello card](https://trello.com/c/GGvHKuad/118-event-tracking-and-analytics-for-iteration-2-of-local-links-manager-3)

Used by https://github.com/alphagov/local-links-manager/pull/109

Extending analytics in govuk_admin_template, which will enable us to send more information when triggering events for GA for projects that use govuk_admin_template (for example: in local-links-manager).
This is already possible in `govuk-frontend-toolkit`.