### PR TITLE
Switch to a more flexible method signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Development
+
+* Changes method call from `GOVUKAdmin.trackEvent(action, label, value)` to `GOVUKAdmin.trackEvent(category, action, options)`. Categories are now mandatory. Calls to `GOVUKAdmin.trackEvent` should be changed to use the latest method signature.  
+
 # 5.0.1
 
 * Compile correct favicon for production.

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -85,32 +85,37 @@
 
   // Google Analytics event tracking
   // Label and value are optional
-  GOVUKAdmin.trackEvent = function(action, label, value) {
-
+  GOVUKAdmin.trackEvent = function(category, action, options) {
+    // Possible values for params: category: 'category', action: 'action', label: 'label', value: 10
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
     // Default category to the page an event occurs on
     // Uses sendBeacon for all events
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
+
+    options = options || {}
+    var value;
     var eventAnalytics = {
           hitType: 'event',
           transport: 'beacon',
-          eventCategory: root.location.pathname,
+          eventCategory: category,
           eventAction: redactEmails(action)
-        };
+    };
 
     // Label is optional
-    if (typeof label === "string") {
-      eventAnalytics.eventLabel = redactEmails(label);
+    if (typeof options.label === "string") {
+      eventAnalytics.eventLabel = redactEmails(options.label);
+      delete options.label;
     }
 
     // Value is optional, but when used must be an
     // integer, otherwise the event will be invalid
     // and not logged
-    if (value) {
-      value = parseInt(value, 10);
+    if (options.value) {
+      value = parseInt(options.value, 10);
       if (typeof value === "number" && !isNaN(value)) {
         eventAnalytics.eventValue = value;
       }
+      delete options.value;
     }
 
     if (typeof root.ga === "function") {

--- a/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/auto_track_event.js
@@ -4,11 +4,12 @@
   Modules.AutoTrackEvent = function() {
     var that = this;
     that.start = function(element) {
-      var action = element.data('track-action'),
+      var category = element.data('track-category'),
+          action = element.data('track-action'),
           label = element.data('track-label'),
           value = element.data('track-value');
 
-      GOVUKAdmin.trackEvent(action, label, value);
+      GOVUKAdmin.trackEvent(category, action, { label: label, value: value });
     }
   };
 

--- a/app/assets/javascripts/govuk-admin-template/modules/track_click.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/track_click.js
@@ -6,10 +6,11 @@
 
     that.start = function(container) {
       var trackClick = function() {
-        var action = container.data("track-action") || "button-pressed",
+        var category = container.data("track-category"),
+            action = container.data("track-action") || "button-pressed",
             label = $(this).data("track-label") || $(this).text();
 
-        GOVUKAdmin.trackEvent(action, label);
+        GOVUKAdmin.trackEvent(category, action, { label: label });
       };
 
       container.on("click", ".js-track", trackClick);

--- a/spec/javascripts/spec/auto_track_event.spec.js
+++ b/spec/javascripts/spec/auto_track_event.spec.js
@@ -7,7 +7,7 @@ describe('An auto event tracker', function() {
 
   beforeEach(function() {
     element = $('\
-      <div data-track-action="action" data-track-label="label" data-track-value="10">\
+      <div data-track-category="category" data-track-action="action" data-track-label="label" data-track-value="10">\
       </div>\
     ');
 
@@ -17,6 +17,6 @@ describe('An auto event tracker', function() {
   it('tracks events on start', function() {
     spyOn(root.GOVUKAdmin, 'trackEvent');
     tracker.start(element);
-    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('action', 'label', 10)
+    expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'label', value: 10 })
   });
 });

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -133,17 +133,12 @@ describe('A GOVUKAdmin app', function() {
       return window.ga.calls.mostRecent().args[1];
     }
 
-    it('uses the current path as the category', function() {
-      GOVUKAdmin.trackEvent('action', 'label');
-      expect(eventObjectFromSpy()['eventCategory']).toBe('/');
-    });
-
     it('sends them to Google Analytics', function() {
-      GOVUKAdmin.trackEvent('action', 'label');
+      GOVUKAdmin.trackEvent('category', 'action', { label: 'label' });
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {
           hitType: 'event',
-          eventCategory: '/',
+          eventCategory: 'category',
           eventAction: 'action',
           eventLabel: 'label',
           transport: 'beacon'
@@ -152,11 +147,11 @@ describe('A GOVUKAdmin app', function() {
     });
 
     it('label is optional', function() {
-      GOVUKAdmin.trackEvent('action');
+      GOVUKAdmin.trackEvent('category', 'action');
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {
           hitType: 'event',
-          eventCategory: '/',
+          eventCategory: 'category',
           eventAction: 'action',
           transport: 'beacon'
         }]
@@ -164,28 +159,28 @@ describe('A GOVUKAdmin app', function() {
     });
 
     it('only sends values if they are parseable as numbers', function() {
-      GOVUKAdmin.trackEvent('action', 'label', '10');
+      GOVUKAdmin.trackEvent('category', 'action', { label: 'label', value: '10' });
       expect(eventObjectFromSpy()['eventValue']).toEqual(10);
 
-      GOVUKAdmin.trackEvent('action', 'label', 10);
+      GOVUKAdmin.trackEvent('category', 'action', { label: 'label', value: '10' });
       expect(eventObjectFromSpy()['eventValue']).toEqual(10);
 
-      GOVUKAdmin.trackEvent('action', 'label', 'not a number');
+      GOVUKAdmin.trackEvent('category', 'action', { label: 'label', value: 'not a number' });
       expect(eventObjectFromSpy()['eventValue']).toEqual(undefined);
     });
 
     it('redacts any email addresses accidentally passed in as actions or labels', function() {
-      GOVUKAdmin.trackEvent('this email@email.com is bad', 'and that a@a.co.uk');
+      GOVUKAdmin.trackEvent('category', 'this email@email.com is bad', { label: 'and that a@a.co.uk' });
       expect(eventObjectFromSpy()['eventAction']).toEqual('this [email] is bad');
       expect(eventObjectFromSpy()['eventLabel']).toEqual('and that [email]');
 
-      GOVUKAdmin.trackEvent('email@email.com');
+      GOVUKAdmin.trackEvent('category', 'email@email.com');
       expect(eventObjectFromSpy()['eventAction']).toEqual('[email]');
 
-      GOVUKAdmin.trackEvent('1@email.com 2@this.com 3@gov.uk 4@business.biz');
+      GOVUKAdmin.trackEvent('category', '1@email.com 2@this.com 3@gov.uk 4@business.biz');
       expect(eventObjectFromSpy()['eventAction']).toEqual('[email] [email] [email] [email]');
 
-      GOVUKAdmin.trackEvent('@something @twitterhandle sent to email@email.com @ 2pm');
+      GOVUKAdmin.trackEvent('category', '@something @twitterhandle sent to email@email.com @ 2pm');
       expect(eventObjectFromSpy()['eventAction']).toEqual('@something @twitterhandle sent to [email] @ 2pm');
     });
   });

--- a/spec/javascripts/spec/track_click.spec.js
+++ b/spec/javascripts/spec/track_click.spec.js
@@ -12,7 +12,7 @@ describe('A click tracker', function() {
   describe('with defaults', function() {
     beforeEach(function() {
       element = $('\
-        <div>\
+        <div data-track-category="userInteraction">\
           <a class="foo js-track">Foo</a>\
           <a class="bar">Bar</a>\
           <button class="js-track">Qux</button>\
@@ -24,14 +24,14 @@ describe('A click tracker', function() {
       spyOn(root.GOVUKAdmin, 'trackEvent');
       tracker.start(element);
       element.find("a.foo").click();
-      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Foo');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('userInteraction', 'button-pressed', { label: 'Foo' });
     });
 
     it('tracks buttons with default action and label', function() {
       spyOn(root.GOVUKAdmin, 'trackEvent');
       tracker.start(element);
       element.find("button").click();
-      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('button-pressed', 'Qux');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('userInteraction', 'button-pressed', { label: 'Qux' });
     });
 
     it('does not track until clicked', function() {
@@ -51,7 +51,7 @@ describe('A click tracker', function() {
   describe('with overrides specified', function(){
     beforeEach(function() {
       element = $('\
-        <div data-track-action="a-press">\
+        <div data-track-action="a-press" data-track-category="userInteraction">\
           <a class="js-track" data-track-label="bar">Foo</a>\
         </div>\
       ');
@@ -61,7 +61,7 @@ describe('A click tracker', function() {
       spyOn(root.GOVUKAdmin, 'trackEvent');
       tracker.start(element);
       element.find("a").click();
-      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('a-press', 'bar');
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('userInteraction', 'a-press', { label: 'bar' });
     });
   });
 });


### PR DESCRIPTION
[Trello card](https://trello.com/c/BW5fA4ar/141-normalizes-ga-tracking-for-admin-gem)

This is a breaking change to the API.

`GOVUKAdmin.trackEvent(options)` will replace `GOVUKAdmin.trackEvent(action, label, value)`
Category is typically the first parameter, and if using the Google docs as reference is required. The original method call we were using was not useful.

This PR came about as a result of the changes made here: https://github.com/alphagov/govuk_admin_template/pull/145