### PR TITLE
Version 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Development
+# 6.0.0
 
 * Changes method call from `GOVUKAdmin.trackEvent(action, label, value)` to `GOVUKAdmin.trackEvent(category, action, options)`. Categories are now mandatory. Calls to `GOVUKAdmin.trackEvent` should be changed to use the latest method signature.  
 

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "5.0.1"
+  VERSION = "6.0.0".freeze
 end


### PR DESCRIPTION
Includes a breaking change. 

Calls to `GOVUKAdmin.trackEvent(action, label, value)` should be changed to use  GOVUKAdmin.trackEvent(category, action, options)