### PR TITLE
Update jquery-rails dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.1.0
+
+* Update the jquery-rails dependency to 4.3.1 for compatibility with the latest
+version of nokogiri
+
 # 6.0.0
 
 * Changes method call from `GOVUKAdmin.trackEvent(action, label, value)` to `GOVUKAdmin.trackEvent(category, action, options)`. Categories are now mandatory. Calls to `GOVUKAdmin.trackEvent` should be changed to use the latest method signature.  

--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rails', '>= 3.2.0'
   gem.add_dependency 'bootstrap-sass', '3.3.5.1'
-  gem.add_dependency 'jquery-rails', '~> 4.1.1'
+  gem.add_dependency 'jquery-rails', '~> 4.3.1'
 
   gem.add_development_dependency 'sass-rails', '5.0.6'
   gem.add_development_dependency 'rspec-rails', '~> 3.5'

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.0.0".freeze
+  VERSION = "6.1.0".freeze
 end


### PR DESCRIPTION
* Bump jquery-rails to the latest version. It depends on nokogiri 1.7, which will allow Rails apps which use govuk_admin_template to use the latests nokogiri.
* Release version 6.1.0

The jquery-rails update adds support for jQuery 3 but continues support for jQuery 1 so the update should not affect the behaviour of this gem.