### PR TITLE
Add set dimension and before page view js content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add `GOVUKAdmin.setDimension` to allow setting custom dimensions for GA
+* Add `before_pageview_js` content block that is injected into the layout template GA code before we track the page view.  This allows for running more GA code (like setting custom dimensions) before the page view is tracked.
 
 # 6.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `GOVUKAdmin.setDimension` to allow setting custom dimensions for GA
+
 # 6.1.0
 
 * Update the jquery-rails dependency to 4.3.1 for compatibility with the latest
@@ -7,7 +11,7 @@ message
 
 # 6.0.0
 
-* Changes method call from `GOVUKAdmin.trackEvent(action, label, value)` to `GOVUKAdmin.trackEvent(category, action, options)`. Categories are now mandatory. Calls to `GOVUKAdmin.trackEvent` should be changed to use the latest method signature.  
+* Changes method call from `GOVUKAdmin.trackEvent(action, label, value)` to `GOVUKAdmin.trackEvent(category, action, options)`. Categories are now mandatory. Calls to `GOVUKAdmin.trackEvent` should be changed to use the latest method signature.
 
 # 5.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `GOVUKAdmin.setDimension` to allow setting custom dimensions for GA
 * Add `before_pageview_js` content block that is injected into the layout template GA code before we track the page view.  This allows for running more GA code (like setting custom dimensions) before the page view is tracked.
+* Add `enable_google_analytics_in_tests` config setting to allow including the GA code block in the layout in Rails test environments.  This allows upstream apps to test any GA code they might include.
 
 # 6.1.0
 

--- a/app/assets/javascripts/govuk-admin-template/govuk-admin.js
+++ b/app/assets/javascripts/govuk-admin-template/govuk-admin.js
@@ -127,6 +127,17 @@
     }
   }
 
+  // Google Analytics custom dimensions
+  GOVUKAdmin.setDimension = function(index, value) {
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
+    // The custom dimension index must be configured within the
+    // Universal Analytics profile
+
+    if (typeof root.ga === "function") {
+      root.ga('set', 'dimension' + index, String(value));
+    }
+  }
+
   /*
     Cookie methods
     ==============

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -121,6 +121,7 @@
 
           ga('create', 'UA-26179049-6', '<%= ENV.fetch('GOVUK_APP_DOMAIN') %>');
           ga('set', 'anonymizeIp', true);
+          <%= content_for(:before_pageview_js) %>
           <% if content_for?(:custom_pageview_fullpath) %>
             GOVUKAdmin.trackPageview('<%= content_for(:custom_pageview_fullpath) %>');
           <% else %>
@@ -130,6 +131,7 @@
       <% elsif Rails.env.development? %>
         <script>
           if (console) {window.ga = function() {console.log.apply(console, arguments);};}
+          <%= content_for(:before_pageview_js) %>
         </script>
       <% end %>
     <% end %>

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -5,6 +5,7 @@
   app_title = content_for?(:app_title) ? yield(:app_title) : GovukAdminTemplate::Config.app_title
   has_navbar_content = GovukAdminTemplate::Config.show_signout || content_for?(:navbar_right) || content_for?(:navbar_items)
   disable_google_analytics = GovukAdminTemplate::Config.disable_google_analytics
+  allow_google_analytics_stub = (Rails.env.development? || (Rails.env.test? && GovukAdminTemplate::Config.enable_google_analytics_in_tests))
 %>
 <!DOCTYPE html>
 <!--[if lte IE 7]><html class="no-js lte-ie7" lang="en"><![endif]-->
@@ -128,7 +129,7 @@
             ga('send', 'pageview');
           <% end %>
         </script>
-      <% elsif Rails.env.development? %>
+      <% elsif allow_google_analytics_stub %>
         <script>
           if (console) {window.ga = function() {console.log.apply(console, arguments);};}
           <%= content_for(:before_pageview_js) %>

--- a/lib/govuk_admin_template/config.rb
+++ b/lib/govuk_admin_template/config.rb
@@ -19,5 +19,9 @@ module GovukAdminTemplate
     # Disable analytics
     # Default: false
     mattr_accessor :disable_google_analytics
+
+    # Enable analytics in tests
+    # Default: false
+    mattr_accessor :enable_google_analytics_in_tests
   end
 end

--- a/spec/javascripts/spec/govuk-admin.spec.js
+++ b/spec/javascripts/spec/govuk-admin.spec.js
@@ -184,4 +184,22 @@ describe('A GOVUKAdmin app', function() {
       expect(eventObjectFromSpy()['eventAction']).toEqual('@something @twitterhandle sent to [email] @ 2pm');
     });
   });
+
+  describe('when dimensions are set', function() {
+    beforeEach(function() {
+      window.ga = function() {};
+      spyOn(window, 'ga');
+    });
+
+    it('sends them to Google Analytics', function() {
+      GOVUKAdmin.setDimension(1, 'something-exciting');
+      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', 'something-exciting']);
+    });
+
+    it('converts the value into a string', function() {
+      GOVUKAdmin.setDimension(1, 2);
+      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', '2']);
+    });
+  });
+
 });


### PR DESCRIPTION
Extracts some of the work from #145 that wasn't included in #146:

* `GOVUKAdmin.setDimension` for setting custom dimensions on GA events
* `content_for(:before_pageview_js)` to allow us to run JS right before the default pageview is tracked.

Ultimately in support of https://trello.com/c/svo2ZN6s/131-custom-dimension-send-user-email-domain-to-ga-for-signon-apps