### PR TITLE
Stop referring to design-principles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Replace references to design principles style-guide with the new location.
 * Add ids to styleguide headings so we can link to them.
 
 # 6.2.0

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Example navbar_items:
 
 ### Date formats
 
-The [gem includes](lib/govuk_admin_template/engine.rb) date and time formats which match the [recommended style](https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times).
+The [gem includes](lib/govuk_admin_template/engine.rb) date and time formats which match the recommended styles for [dates](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) and [times](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times).
 
 ```ruby
 # 1 January 2013

--- a/app/views/govuk_admin_template/_govspeak_help.html.erb
+++ b/app/views/govuk_admin_template/_govspeak_help.html.erb
@@ -1,6 +1,6 @@
 <div class="govspeak-help">
   <h2>Writing style</h2>
-  <p>For style, see the <a href="https://www.gov.uk/designprinciples/styleguide">style guide</a></p>
+  <p>For style, see the <a href="https://www.gov.uk/topic/government-digital-guidance/content-publishing">style guide</a></p>
 
   <h2>Formatting help</h2>
   <%= yield :format_specific_help %>

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -179,7 +179,7 @@
 <h2 id="dates">Dates</h2>
 <div class="row">
   <p class="col-md-6 lead">
-    The gem includes date and time formats which match the <a href="https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times">recommended style</a>.
+    The gem includes date and time formats which match the recommended styles for <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates">dates</a> and <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times">times</a>.
   </p>
   <section class="col-md-6">
     <h2 class="remove-top-margin">Default</h2>

--- a/lib/govuk_admin_template/engine.rb
+++ b/lib/govuk_admin_template/engine.rb
@@ -11,7 +11,8 @@ module GovukAdminTemplate
     end
 
     # User friendly GOV.UK date formats, based on:
-    # https://www.gov.uk/design-principles/style-guide/style-points#style-dates-and-times
+    # https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+    # https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times
     initializer 'govuk_admin_template.date_formats' do |app|
       # 1 January 2013
       Date::DATE_FORMATS[:govuk_date] = '%-e %B %Y'


### PR DESCRIPTION
For: https://trello.com/c/M45WyUGZ/261-retire-design-principles

Design-principles is going away so we should stop having links to its
pages in our apps.  There are new pages for all the things we linked to
so we replace the old urls with the new ones.