### PR TITLE
Allow setting a custom class on the root HTML tag

### DIFF
--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -8,9 +8,9 @@
   allow_google_analytics_stub = (Rails.env.development? || (Rails.env.test? && GovukAdminTemplate::Config.enable_google_analytics_in_tests))
 %>
 <!DOCTYPE html>
-<!--[if lte IE 7]><html class="no-js lte-ie7" lang="en"><![endif]-->
-<!--[if IE 8]><html class="no-js ie8" lang="en"><![endif]-->
-<!--[if gt IE 8]><!--><html class="no-js" lang="en"><!--<![endif]-->
+<!--[if lte IE 7]><html class="no-js lte-ie7 <%= yield(:html_class) %>" lang="en"><![endif]-->
+<!--[if IE 8]><html class="no-js ie8 <%= yield(:html_class) %>" lang="en"><![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js <%= yield(:html_class) %>" lang="en"><!--<![endif]-->
   <head>
     <meta charset="utf-8">
     <title><%= content_for?(:page_title) ? yield(:page_title) : app_title %></title>


### PR DESCRIPTION
This change allows the insertion of a custom class on the root
`<html>` tag in the Admin Template.

This is useful when making more drastic styling changes to the template.
The class is set at such a high level in the DOM because this allows:

- changing of styles on the `html` tag itself (ie `overflow-y`)
- arbitrary restyling of anything else in the DOM

This change is primarily to allow a side-by-side layout in the Audit
Tool.