### PR TITLE
Release version 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 6.3.0
+
+* Add `assets:clobber` placeholder rake task
+* Allow setting a class on the root `<html>` tag
 * Replace references to design principles style-guide with the new location.
 * Add ids to styleguide headings so we can link to them.
 

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.2.0".freeze
+  VERSION = "6.3.0".freeze
 end


### PR DESCRIPTION
- Allow setting a class on the root `<html>` tag
- Replace references to design principles style-guide with the new location.
- Add ids to styleguide headings so we can link to them.