### PR TITLE
Add an `ie9` class when using Internet Explorer 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `ie9` class to root `<html>` tag when user is using Internet Explorer 9
+
 # 6.3.0
 
 * Add `assets:clobber` placeholder rake task

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -10,7 +10,8 @@
 <!DOCTYPE html>
 <!--[if lte IE 7]><html class="no-js lte-ie7 <%= yield(:html_class) %>" lang="en"><![endif]-->
 <!--[if IE 8]><html class="no-js ie8 <%= yield(:html_class) %>" lang="en"><![endif]-->
-<!--[if gt IE 8]><!--><html class="no-js <%= yield(:html_class) %>" lang="en"><!--<![endif]-->
+<!--[if IE 9]><html class="no-js ie9 <%= yield(:html_class) %>" lang="en"><![endif]-->
+<!--[if gt IE 9]><!--><html class="no-js <%= yield(:html_class) %>" lang="en"><!--<![endif]-->
   <head>
     <meta charset="utf-8">
     <title><%= content_for?(:page_title) ? yield(:page_title) : app_title %></title>


### PR DESCRIPTION
There are certain features that Internet Explorer 9 does not support,
such as CSS animation.

This change adds a conditional class to the root `<html>` tag in the
same way we already do for IE7 and IE8.