### PR TITLE
Bump version to 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 6.4.0
+
 * Add `ie9` class to root `<html>` tag when user is using Internet Explorer 9
 
 # 6.3.0

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.3.0".freeze
+  VERSION = "6.4.0".freeze
 end


### PR DESCRIPTION
* Add `ie9` class to root `<html>` tag when user is using Internet Explorer 9