### PR TITLE
Allow customisation of track click selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Remove IE7 support
+* Allow track-click to be customised with a selector
+
 # 6.4.0
 
 * Add `ie9` class to root `<html>` tag when user is using Internet Explorer 9

--- a/app/assets/javascripts/govuk-admin-template/modules/track_click.js
+++ b/app/assets/javascripts/govuk-admin-template/modules/track_click.js
@@ -5,6 +5,7 @@
     var that = this;
 
     that.start = function(container) {
+      var selector = container.data("track-selector") || '.js-track';
       var trackClick = function() {
         var category = container.data("track-category"),
             action = container.data("track-action") || "button-pressed",
@@ -13,7 +14,7 @@
         GOVUKAdmin.trackEvent(category, action, { label: label });
       };
 
-      container.on("click", ".js-track", trackClick);
+      container.on("click", selector, trackClick);
     }
   };
 

--- a/spec/javascripts/spec/track_click.spec.js
+++ b/spec/javascripts/spec/track_click.spec.js
@@ -64,4 +64,37 @@ describe('A click tracker', function() {
       expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('userInteraction', 'a-press', { label: 'bar' });
     });
   });
+
+  describe('with selector specified', function(){
+    beforeEach(function() {
+      element = $('\
+        <div data-track-category="userInteraction" data-track-selector=".custom-track-class">\
+          <a class="foo custom-track-class">Foo</a>\
+          <a class="bar">Bar</a>\
+          <button class="custom-track-class">Qux</button>\
+        </div>\
+      ');
+    });
+
+    it('tracks links with default action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("a.foo").click();
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('userInteraction', 'button-pressed', { label: 'Foo' });
+    });
+
+    it('tracks buttons with default action and label', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("button").click();
+      expect(GOVUKAdmin.trackEvent).toHaveBeenCalledWith('userInteraction', 'button-pressed', { label: 'Qux' });
+    });
+
+    it('does not track if not enabled', function() {
+      spyOn(root.GOVUKAdmin, 'trackEvent');
+      tracker.start(element);
+      element.find("a.bar").click();
+      expect(GOVUKAdmin.trackEvent).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Avoid having to add `.js-track` classes to every element that should be tracked.
eg Whitehall needs to add click tracking to most buttons (`.btn`).