### PR TITLE
Fix colour contrast issues

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_base.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_base.scss
@@ -282,7 +282,7 @@ a.list-group-item {
 
 .link-muted:hover,
 .link-muted:focus {
-  color: $gray;
+  color: #000;
 }
 
 .link-inherit,
@@ -304,7 +304,7 @@ a.list-group-item {
   font-size: 65%;
   font-weight: normal;
   line-height: 1.5;
-  color: $gray-light;
+  color: $gray;
   display: block;
 }
 

--- a/app/assets/stylesheets/govuk_admin_template/_base.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_base.scss
@@ -276,7 +276,7 @@ a.list-group-item {
 
 .link-muted,
 .link-muted:visited {
-  color: $gray-light;
+  color: $gray-dark;
   text-decoration: underline;
 }
 
@@ -360,7 +360,7 @@ a.list-group-item {
 }
 
 .no-content {
-  color: lighten($gray-light, 20%); // Large text needs a lighter colour for balance
+  color: $gray;
   @extend %large-and-spaced;
 }
 

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_colour_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_colour_overrides.scss
@@ -5,4 +5,35 @@
   This assumed gray-light was on a light background. We aren't always
   using it in that way. Reset to the original value #999.
 */
+
 $gray-light: lighten(#000, 60%);
+
+/*
+  Updates a bunch of copy that used to be gray to black for things like labels.
+*/
+$text-color: #000;
+
+/*
+  Updates the input to black so it contrasts with the light gray background.
+*/
+$input-color: #000;
+
+/*
+  Updates muted text to gray so it contrasts with the light gray background.
+*/
+$text-muted: #444;
+
+/*
+  Updates text in the breadcrumbs to use a darker gray to fix contrast issues.
+*/
+$breadcrumb-active-color: #444;
+
+/*
+  Updates the spans in headers to use a darker gray to fix contrast issues.
+*/
+$headings-small-color: #444;
+
+/*
+  Updates the disabled pagination links to use a darker gray to fix contrast issues.
+*/
+$pagination-disabled-color: #444;

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_colour_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_colour_overrides.scss
@@ -37,3 +37,9 @@ $headings-small-color: #444;
   Updates the disabled pagination links to use a darker gray to fix contrast issues.
 */
 $pagination-disabled-color: #444;
+
+/*
+  Updates the default link to colour to a the same colour used in the
+  GOVUK design system. This fixes some contrast issues.
+*/
+$link-color: #1d70b8;

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_colour_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_colour_overrides.scss
@@ -1,3 +1,7 @@
+$black: #000;
+$gray-dark: #444;
+$blue: #1d70b8;
+
 /*
   Bootstrap 3.2 made gray-light darker for accessibility and contrast:
   https://github.com/twbs/bootstrap/releases/tag/v3.2.0
@@ -6,40 +10,40 @@
   using it in that way. Reset to the original value #999.
 */
 
-$gray-light: lighten(#000, 60%);
+$gray-light: lighten($black, 60%);
 
 /*
   Updates a bunch of copy that used to be gray to black for things like labels.
 */
-$text-color: #000;
+$text-color: $black;
 
 /*
   Updates the input to black so it contrasts with the light gray background.
 */
-$input-color: #000;
+$input-color: $black;
 
 /*
   Updates muted text to gray so it contrasts with the light gray background.
 */
-$text-muted: #444;
+$text-muted: $gray-dark;
 
 /*
   Updates text in the breadcrumbs to use a darker gray to fix contrast issues.
 */
-$breadcrumb-active-color: #444;
+$breadcrumb-active-color: $gray-dark;
 
 /*
   Updates the spans in headers to use a darker gray to fix contrast issues.
 */
-$headings-small-color: #444;
+$headings-small-color: $gray-dark;
 
 /*
   Updates the disabled pagination links to use a darker gray to fix contrast issues.
 */
-$pagination-disabled-color: #444;
+$pagination-disabled-color: $gray-dark;
 
 /*
   Updates the default link to colour to a the same colour used in the
   GOVUK design system. This fixes some contrast issues.
 */
-$link-color: #1d70b8;
+$link-color: $blue;

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
@@ -1,5 +1,18 @@
 @import 'govuk_admin_template/buttons'; // overrides bootstrap buttons
 
+$govuk-tag-dark-grey: #383f43;
+$govuk-tag-light-gray: #eeefef;
+$govuk-tag-mid-blue: #1d70b8;
+$govuk-tag-white: #fff;
+$govuk-tag-dark-green: #005a30;
+$govuk-tag-light-green: #cce2d8;
+$govuk-tag-dark-blue: #144e81;
+$govuk-tag-light-blue: #d2e2f1;
+$govuk-tag-dark-yellow: #594d00;
+$govuk-tag-light-yellow: #fff7bf;
+$govuk-tag-dark-red: #942514;
+$govuk-tag-light-red: #f6d7d2;
+
 /*
   The admin gem's navbar has a bottom margin, for correct spacing
   when the page-header class isn't used. To account for this reduce
@@ -24,31 +37,31 @@
 // Overrides the lables to use same colour scheme as the GOVUK design system
 
 .label-default {
-  color: #383f43;
-  background: #eeefef;
+  color: $govuk-tag-dark-grey;
+  background: $govuk-tag-light-gray;
 }
 
 .label-primary {
-  color: #fff;
-  background: #1d70b8;
+  color: $govuk-tag-mid-blue;
+  background: $govuk-tag-white;
 }
 
 .label-success {
-  color: #005a30;
-  background: #cce2d8;
+  color: $govuk-tag-dark-green;
+  background: $govuk-tag-light-green;
 }
 
 .label-info {
-  color: #144e81;
-  background: #d2e2f1;
+  color: $govuk-tag-dark-blue;
+  background: $govuk-tag-light-blue;
 }
 
 .label-warning {
-  color: #594d00;
-  background: #fff7bf;
+  color: $govuk-tag-dark-yellow;
+  background: $govuk-tag-light-yellow;
 }
 
 .label-danger {
-  color: #942514;
-  background: #f6d7d2;
+  color: $govuk-tag-dark-red;
+  background: $govuk-tag-light-red;
 }

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
@@ -20,3 +20,35 @@
   font-weight: normal;
   color: #555;
 }
+
+// Overrides the lables to use same colour scheme as the GOVUK design system
+
+.label-default {
+  color: #383f43;
+  background: #eeefef;
+}
+
+.label-primary {
+  color: #fff;
+  background: #1d70b8;
+}
+
+.label-success {
+  color: #005a30;
+  background: #cce2d8;
+}
+
+.label-info {
+  color: #144e81;
+  background: #d2e2f1;
+}
+
+.label-warning {
+  color: #594d00;
+  background: #fff7bf;
+}
+
+.label-danger {
+  color: #942514;
+  background: #f6d7d2;
+}

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
@@ -19,8 +19,4 @@
 .lead {
   font-weight: normal;
   color: #555;
-
-  &.text-muted {
-    color: $gray-light;
-  }
 }

--- a/app/assets/stylesheets/govuk_admin_template/_nav_list.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_nav_list.scss
@@ -20,7 +20,7 @@
     font-size: 11px;
     font-weight: bold;
     line-height: $line-height-computed;
-    color: $gray-light;
+    color: $gray;
     text-transform: uppercase;
   }
 
@@ -28,6 +28,11 @@
   li + .nav-header {
     margin-top: 9px;
   }
+}
+
+.nav-tabs .badge {
+  color: #fff;
+  background: #666;
 }
 
 .nav-list > li > a,

--- a/app/assets/stylesheets/govuk_admin_template/_navbar.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_navbar.scss
@@ -116,3 +116,8 @@ header .navbar-header {
   background-color: $dev-color;
   color: #000;
 }
+
+.sidebar-nav .badge {
+  color: #fff;
+  background: #666;
+}


### PR DESCRIPTION
### Description

All of our applications that use this gem get flagged for colour contrast issues by Wave accessibility tool. This PR attempts to address these issues. The vast majority of the issues come from the use of light grey being used on a white background. Or a mid grey being used on a light grey background.

I've largely tried to apply fixes by darkening the text colour. Generally text that used to be light grey is now mid-grey, text that was mid grey is now dark grey and text that were dark grey is now black.

### Changes 

1. Uses black as the default text colour. This encompasses things like labels, table headings etc.

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151552220-2f780a71-19d5-452f-b6cf-3592bd140e91.png)|![image](https://user-images.githubusercontent.com/42515961/151552873-0d3f0f84-18a4-4d8e-a600-eaba60afb35c.png)|

2. Uses black as the default input colour.

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151554018-7453b9a2-c04e-4c49-8347-10dd91b0c642.png)|![image](https://user-images.githubusercontent.com/42515961/151553885-64ef5ef7-c18a-432e-b49f-2c2af2abf31a.png)|

3. Uses a mid grey for muted text

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151554983-5cccaac3-e0bc-4514-907b-39c9c8d6c2a7.png)|![image](https://user-images.githubusercontent.com/42515961/151555181-b85f1d5b-58b0-4888-9799-3b6df46f3c1c.png)|

4. Updates the breadcrumb text to mid grey instead of light grey 

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151556540-0eceba15-8c29-4190-a8b3-0c6836958dcd.png)|![image](https://user-images.githubusercontent.com/42515961/151556608-1685ff89-e800-472c-9f91-0f235432ae3c.png)|


5. Updates small headings to use mid grey

This fixes contrast issues when they render on a light grey background

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151572169-b469205c-d38f-4b35-b774-7440d4c82e6b.png)|![image](https://user-images.githubusercontent.com/42515961/151572243-4f985728-66be-43b6-94b8-746b6436b634.png)|



6. Uses mid grey for pagination disabled links 

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151560270-db745015-acbf-443e-937d-59c38cb5e64c.png)|![image](https://user-images.githubusercontent.com/42515961/151560336-1738a680-95ce-433b-b33f-5d1be81ff1f8.png)|


7. Updates the nav sidebar labels to have a darker grey background

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151561154-b653a6a0-26ec-427e-a76d-778d05a9af13.png)|![image](https://user-images.githubusercontent.com/42515961/151578934-ce5716c1-87cf-412d-ac88-14c77fc91b60.png)|


8.  Uses a darker grey background for nav tabs labels

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151562674-ed0b9477-016e-42e9-8361-79255f981b2d.png)|![image](https://user-images.githubusercontent.com/42515961/151578812-d81384ba-343b-4cf8-8edb-7e09035b3e15.png)|

9. Use a slightly darker blue for links and dark grey for muted links

I've pulled the blue from the design system

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151564094-71d7195e-0617-4e31-9c7d-f5c9a4bf60c5.png)|![image](https://user-images.githubusercontent.com/42515961/151563950-ebc04287-f4c5-43e5-965a-d180cc5ed9f3.png)|

10. update content tag labels to use the GOVUK Design System colours

Default

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151565693-2850f8cd-9563-4265-9604-0326cfef7ca5.png)|![image](https://user-images.githubusercontent.com/42515961/151565762-58162f91-481c-450d-bff0-553ae95e0a39.png)|

Primary

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151566082-d24050cc-26d2-4b72-aac2-6024acbb35ce.png)|![image](https://user-images.githubusercontent.com/42515961/151566578-03355e3f-7b6e-4d11-963e-2ec00ca90533.png)|

Success

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151566452-49662501-b440-4c94-b917-97f937408a8b.png)|![image](https://user-images.githubusercontent.com/42515961/151566341-435da6d9-6159-4536-8e06-4ffbe930f6ad.png)|

Info

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151566710-8cb5cdb7-47d3-45ea-a151-197388886adf.png)|![image](https://user-images.githubusercontent.com/42515961/151565922-e7684c21-9212-4f52-8834-bf4ce129c56f.png)|

Warning

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151566997-dab1d0e7-1be5-40d1-b0c3-d8240e2c1fc7.png)|![image](https://user-images.githubusercontent.com/42515961/151566902-cda886cf-f8ee-4375-9e35-e41f0f25d58e.png)|

Danger 

|Before|After|
|------------|------------|
|![image](https://user-images.githubusercontent.com/42515961/151567473-56bd1238-3481-4e96-8157-f62841ec25c9.png)|![image](https://user-images.githubusercontent.com/42515961/151567145-c10d3583-c038-4e4d-b122-0217a64dceaf.png)|

### Guidance for review

In order to review these changes using govuk docker you do the following:

1. Clone govuk_admin_template repo into ~/govuk
2. In govuk-docker, add a ‘volume’ mount to the app’s docker-compose.yml file.

For all applications except Whitehall it would be (add in your name to the interpolation):
```
    - /Users/#{your}.#{name}/govuk/govuk_admin_template:/root/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/govuk_admin_template-6.7.0

```
and for Whitehall it would be 

```
  - /Users/#{your}.#{name}/govuk/govuk_admin_template:/root/.rbenv/versions/2.6.6/lib/ruby/gems/2.7.0/gems/govuk_admin_template-6.7.0
```

![image](https://user-images.githubusercontent.com/42515961/151541316-3835590e-cc72-4f20-9e39-170a4544b87f.png)

You could also add Wave as a plugin to your browser here https://wave.webaim.org/extension/


### Trello card

https://trello.com/c/DpKuwIea/152-fix-colour-contrast-issues-in-the-govukadmintemplate-gem
