### PR TITLE
Fix bug where govspeak help links are skipped when tabbing

### DIFF
--- a/app/views/govuk_admin_template/_govspeak_help.html.erb
+++ b/app/views/govuk_admin_template/_govspeak_help.html.erb
@@ -5,7 +5,7 @@
   <h2>Formatting help</h2>
   <%= yield :format_specific_help %>
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-headings">
+    <a data-toggle="collapse" href="#govspeak-headings">
       Headings
     </a>
   </h3>
@@ -18,7 +18,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-links">
+    <a data-toggle="collapse" href="#govspeak-links">
       Links
     </a>
   </h3>
@@ -54,7 +54,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-bullets">
+    <a data-toggle="collapse" href="#govspeak-bullets">
       Bullets
     </a>
   </h3>
@@ -67,7 +67,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-numbered-list">
+    <a data-toggle="collapse" href="#govspeak-numbered-list">
       Numbered list
     </a>
   </h3>
@@ -81,7 +81,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-priority-list">
+    <a data-toggle="collapse" href="#govspeak-priority-list">
       Priority list
     </a>
   </h3>
@@ -98,7 +98,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-legislative-list">
+    <a data-toggle="collapse" href="#govspeak-legislative-list">
       Legislative list
     </a>
   </h3>
@@ -120,7 +120,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-tables">
+    <a data-toggle="collapse" href="#govspeak-tables">
       Tables
     </a>
   </h3>
@@ -139,7 +139,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-cta">
+    <a data-toggle="collapse" href="#govspeak-cta">
       Call to action
     </a>
   </h3>
@@ -150,7 +150,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-abbreviations-and-acronyms">
+    <a data-toggle="collapse" href="#govspeak-abbreviations-and-acronyms">
       Abbreviations and acronyms
     </a>
   </h3>
@@ -164,7 +164,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-blockquotes">
+    <a data-toggle="collapse" href="#govspeak-blockquotes">
       Blockquotes
     </a>
   </h3>
@@ -178,7 +178,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-addresses">
+    <a data-toggle="collapse" href="#govspeak-addresses">
       Addresses
     </a>
   </h3>
@@ -192,7 +192,7 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" data-target="#govspeak-footnotes">
+    <a data-toggle="collapse" href="#govspeak-footnotes">
       Footnotes
     </a>
   </h3>

--- a/app/views/govuk_admin_template/_govspeak_help.html.erb
+++ b/app/views/govuk_admin_template/_govspeak_help.html.erb
@@ -155,10 +155,7 @@
     </a>
   </h3>
   <div class="collapse" id="govspeak-abbreviations-and-acronyms">
-    <pre>Example content containing DWP and EU acronyms.
-
-  *[EU]: European Union
-  *[DWP]: Department for Work and Pensions</pre>
+    <pre>*[DWP]: Department for Work and Pensions</pre>
     <p>Text found in content which matches what’s in the brackets <code>[ ]</code> (eg DWP), will have the full text (Department for Work and Pensions) available to screenreaders and when hovering: <abbr title="Department for Work and Pensions">DWP</abbr>. The markdown code will not be displayed.</p>
     <p>List abbreviation markdown at the end.</p>
   </div>


### PR DESCRIPTION
## Description

At the moment, when you try and navigate the page via tabbing, you skip over the govspeak guidance links. This means that people using a keyboard or screen reader won't be able to access it.

This fixes the issue by adding an href link which points the the collapsable div.

![image](https://user-images.githubusercontent.com/42515961/150560032-47bc511f-7c68-4528-a779-7e724fcd595c.png)

The best way to test this is to follow the guidance for review section in #215 

Then run the applications locally and check that it has the desired behaviour.

## Trello card

https://trello.com/c/zcuUtMoD/359-cant-access-govspeak-guidance-when-navigating-with-tab