### PR TITLE
Increase label font size to 80%

### DIFF
--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
@@ -24,3 +24,7 @@
     color: $gray-light;
   }
 }
+
+.label {
+  font-size: 80%;
+}


### PR DESCRIPTION
Previously wave was complaining that the font size was too small in the labels. By bumping it to 80% it is WCAG compliant.