### PR TITLE
Only run RSpec tests once

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new(:spec)
 
 # The jasmine gem isn't designed for testing engines
 #
@@ -34,4 +33,7 @@ end
 # Load local tasks
 Rails.application.load_tasks
 
+# RSpec shoves itself into the default task without asking, which confuses the ordering.
+# https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 task default: ["lint", :spec, "dummy_app:jasmine:ci", "sass:check"]


### PR DESCRIPTION
A change made in in #218 to the Rakefile resulted in RSpec tests inadvertently being run twice with `bundle exec rake`.

This commit changes the `:default` Rake task so that the RSpec test suite is only run once. It uses the same approach as that used in [contacts-admin](https://github.com/alphagov/contacts-admin/blob/3d190f9541e04a56d7c819da9334820237ea7ac9/Rakefile#L4-L7).