### PR TITLE
Bump to 6.8.0 and update the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# 6.8.0
 
 * Replace the development dependency govuk-lint with rubocop-govuk
+* Fix colour contrast issues flagged by WAVE Web Accessibility Evaluation Tool
+* Ensure govspeak guidance can be navigated to via keyboard tabbing
 
 # 6.7.0
 

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.7.0".freeze
+  VERSION = "6.8.0".freeze
 end


### PR DESCRIPTION
This bumps the version of in the version.rb file to 6.8.0 and documents the changes in the CHANGELOG.

I've kept the description of the changes fairly minimal. Happy to be more verbose, but it would be quite lengthy.

Once this has been reviewed and merged, we will need to deploy it. The README says this will automatically trigger a rubygems update.