### PR TITLE
Fix colour contrast issue in labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.8.1
+
+* Ensure labels have sufficient colour contrast
+
 # 6.8.0
 
 * Replace the development dependency govuk-lint with rubocop-govuk

--- a/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/govuk_admin_template/_bootstrap_overrides.scss
@@ -42,8 +42,8 @@ $govuk-tag-light-red: #f6d7d2;
 }
 
 .label-primary {
-  color: $govuk-tag-mid-blue;
-  background: $govuk-tag-white;
+  color: $govuk-tag-white;
+  background: $govuk-tag-mid-blue;
 }
 
 .label-success {

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.8.0".freeze
+  VERSION = "6.8.1".freeze
 end


### PR DESCRIPTION
For the .label-primary the background colour and text colour were swapped when assigning them to variables. This has caused an issue with the colour contrast.

Unfortunately as the previous changes were pushed to rubygems, the version needs to be bumped.