### PR TITLE
Update CI workflow to use `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
So that we can rename the `master` branch to `main`.

Trello: https://trello.com/c/kAh24TRP/303-bring-govukadmintemplate-up-to-speed