### PR TITLE
Fixup documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Rails 7 compatibility: use `Time#to_fs` instead of deprecated use of `Time#to_s`
 * Bump minimum supported Rails version to 6
+* Fix broken 'Crown Copyright' link in the layout template page footer
 
 # 6.8.1
 

--- a/CSS.md
+++ b/CSS.md
@@ -9,20 +9,20 @@ CSS in the gem follows two conventions:
 ## Available helper classes
 
 Firstly, the admin styles are based on Bootstrap:
-* [Bootstrap CSS](http://getbootstrap.com/css/)
-* [Bootstrap Components](http://getbootstrap.com/components/)
+* [Bootstrap CSS](https://getbootstrap.com/docs/3.4/css/)
+* [Bootstrap Components](https://getbootstrap.com/docs/3.4/components/)
 
 For admin components, see the admin style guide (`/style-guide` in your app).
 
 ### Hide and show content
-[toggle.css.scss](app/assets/stylesheets/govuk_admin_template/_toggles.css.scss)
+See: [toggles.scss](app/assets/stylesheets/govuk_admin_template/_toggles.scss)
 
 Class   | Purpose
 ------  |--------
 `hide` | Hide content from all users, including screenreaders
 `if-no-js-hide` | Hide from users without Javascript
 `if-js-hide` | Hide from users with Javascript
-`rm` | [Hide visually](http://snook.ca/archives/html_and_css/hiding-content-for-accessibility) but keep available to screenreaders
+`rm` | [Hide visually](https://snook.ca/archives/html_and_css/hiding-content-for-accessibility) but keep available to screenreaders
 `if-js-rm` | Hide visually from users with Javascript
 
 ### Margin helpers
@@ -35,7 +35,7 @@ Rather than creating a class purely to remove or add margins (many Bootstrap sty
 
 The mixins don’t include `!important` by default, but can be added as a parameter:
 
-```sass
+```scss
 .class {
   @include add-top-margin;
   @include add-top-margin('!important');
@@ -61,7 +61,7 @@ Like the margin helpers, the padding classes include `!important` so they’ll a
 <h3 class="add-bottom-padding"></h3>
 ```
 
-```sass
+```scss
 .class {
   @include add-top-padding;
   @include add-top-padding('!important');
@@ -105,7 +105,7 @@ Class   | Purpose
 `inline-block` | Display inline-block
 
 ### Tables
-[tables.css.scss](app/assets/stylesheets/govuk_admin_template/_tables.css.scss)
+See: [tables.scss](app/assets/stylesheets/govuk_admin_template/_tables.scss)
 
 Class   | Purpose
 ------  |--------
@@ -114,7 +114,7 @@ Class   | Purpose
 
 ### SASS Variables
 
-Along with Bootstrap’s many [mixins](https://github.com/twbs/bootstrap-sass/blob/master/vendor/assets/stylesheets/bootstrap/_mixins.scss) and [variables](http://getbootstrap.com/customize/#less-variables), the admin gem comes with [some of its own](app/assets/stylesheets/govuk_admin_template/_theme.css.scss).
+Along with Bootstrap’s many [mixins](https://github.com/twbs/bootstrap-sass/blob/v3.4.1/assets/stylesheets/bootstrap/_mixins.scss) and [variables](https://github.com/twbs/bootstrap-sass/blob/v3.4.1/assets/stylesheets/bootstrap/_variables.scss), the admin gem comes with [some of its own](app/assets/stylesheets/govuk_admin_template/_theme.scss).
 
 Class   | Purpose
 ------  |--------

--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -39,7 +39,7 @@ The simplest of modules looks like this:
 
 ## Writing modules
 
-Whilst this isn’t prescriptive, it helps if modules look and behave in a similar manner. Modules should live within your app’s `app\assets\javascripts\modules` directory.
+Whilst this isn’t prescriptive, it helps if modules look and behave in a similar manner. Modules should live within your app’s `app/assets/javascripts/modules` directory.
 
 ### Use `js-` prefixed classes for interaction hooks
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-Styles, scripts and templates wrapped up in a gem for getting up and running with [Bootstrap](http://getbootstrap.com) based backend admin apps.
+Styles, scripts and templates wrapped up in a gem for getting up and running with [Bootstrap 3.4](https://getbootstrap.com/docs/3.4/) based backend admin apps.
 
 This gem provides (via a Rails engine):
 * jQuery
@@ -35,10 +35,10 @@ Firstly, include the gem in your Gemfile, pinned to the appropriate version and 
 
 ```ruby
 # Gemfile
-gem 'govuk_admin_template', '~> 3.3'
+gem 'govuk_admin_template', '~> 6.8'
 ```
 
-At the top of `application.scss` include the styles (this provides all the mixins and variables from the gem as well as from bootstrap — [bootstrap mixins](https://github.com/twbs/bootstrap-sass/blob/master/vendor/assets/stylesheets/bootstrap/_mixins.scss)):
+At the top of `application.scss` include the styles (this provides all the mixins and variables from the gem as well as from bootstrap — [bootstrap mixins](https://github.com/twbs/bootstrap-sass/blob/v3.4.1/assets/stylesheets/bootstrap/_mixins.scss)):
 ```css
 /* application.scss */
 @import 'govuk_admin_template';
@@ -71,11 +71,13 @@ You will also need to include your styles and javascripts:
 Note that `jquery` and `jquery_ujs` are already imported by `govuk_admin_template`,
 so you should remove them from your `app/assets/javascripts/application.js`. This may
 cause your jasmine tests to fail, so you'll need to include `assets/govuk-admin-template.js`
-in your `spec/javascripts/support/jasmine.yml` like this:
+in your `spec/support/jasmine-browser.json` like this:
 
-```yaml
-src_files:
-  - assets/govuk-admin-template.js
+```json
+"srcFiles": [
+  "govuk-admin-template-*.js",
+  "application-*.js"
+]
 ```
 
 It is recommended that the style guide is also made available within your app at the route `/style-guide`. Add this to your `config/routes.rb` file:
@@ -87,7 +89,7 @@ if Rails.env.development?
 end
 ```
 
-The gem source includes a [dummy app](spec/dummy) configured to behave like an app using the gem. If you have the gem checked out it can be run from the `spec\dummy` directory using `rails s`.
+The gem source includes a [dummy app](spec/dummy) configured to behave like an app using the gem. If you have the gem checked out it can be run from the `spec/dummy` directory using `rails s`.
 
 For Javascript usage, available modules and writing modules, see the [Javascript guide](JAVASCRIPT.md).
 
@@ -118,7 +120,7 @@ To use this configuration:
 0. Add an initializer in `config/initializers/simple_form.rb` containing the
    following:
 
-```
+```ruby
 SimpleForm.setup do |config|
   GovukAdminTemplate.setup_simple_form(config)
 end
@@ -130,7 +132,7 @@ specific customisations are required.
 
 ### Content blocks
 
-The gem [uses nested layouts](http://guides.rubyonrails.org/layouts_and_rendering.html#using-nested-layouts) for customisation.
+The gem [uses nested layouts](https://guides.rubyonrails.org/layouts_and_rendering.html#using-nested-layouts) for customisation.
 
 `content_for`     | Description
 ---------------   | -------------
@@ -164,19 +166,19 @@ The [gem includes](lib/govuk_admin_template/engine.rb) date and time formats whi
 
 ```ruby
 # 1 January 2013
-date.to_s(:govuk_date)
+date.to_fs(:govuk_date)
 
 # 1:15pm, 1 January 2013
-time.to_s(:govuk_date)
+time.to_fs(:govuk_date)
 
 # 1 Jan 2013
-date.to_s(:govuk_date_short)
+date.to_fs(:govuk_date_short)
 
 # 1:15pm, 1 Jan 2013
-time.to_s(:govuk_date_short)
+time.to_fs(:govuk_date_short)
 
 # 1:15pm
-time.to_s(:govuk_time)
+time.to_fs(:govuk_time)
 ```
 
 ### Environment indicators
@@ -225,7 +227,7 @@ We support `:success`, `:info`, `:warning` and `:danger`:
 
 ![Flash types](docs/flash-types.png)
 
-In Rails 4, you can register your types to allow them to be used as arguments
+You can register your types to allow them to be used as arguments
 to `redirect_to`.
 
 ```ruby
@@ -249,7 +251,7 @@ The source files are in the [app](app) directory. Unlike other GOVUK frontend ge
 
 While developing it may be helpful to see how the gem will render. The dummy app at [spec/dummy](spec/dummy) is configured to act like an application using the gem and can be started from that directory using `rails s`. Changes will show immediately. The tests also run against this app.
 
-The dummy app’s rake tasks have been loaded into the gem’s task list under the namespace `dummy_app` for convenience.
+The dummy app’s rake tasks have been loaded into the gem’s task list under the namespace `app` for convenience – e.g. `bundle exec rake app:assets:precompile`
 
 ### Running tests
 
@@ -263,7 +265,7 @@ Layout and nested layouts are tested using RSpec and Capybara:
 bundle exec rake spec
 ```
 
-Javascript is tested using Jasmine and [jasmine-browser-runner](https://jasmine.github.io/setup/browser.html). Tests can be run either in the browser or on the command line via the dummy app’s tasks:
+Javascript is tested using Jasmine and [jasmine-browser-runner](https://jasmine.github.io/setup/browser.html). Tests can be run either in the browser or on the command line:
 ```sh
 # browser
 yarn run jasmine:browser

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -6,10 +6,10 @@
   </h1>
 </div>
 
-<p class="lead">Admin app UIs are powered by <a href="http://getbootstrap.com/css/">bootstrap 3.3.2</a>, using <a href="https://github.com/twbs/bootstrap-sass/tree/v3.3.3">bootstrap SASS</a> v3.3.3 (<a href="https://github.com/twbs/bootstrap-sass/blob/v3.3.3/assets/stylesheets/bootstrap/_mixins.scss">mixins</a>), but maintaining bootstrap 2 button styles. This guide documents how we use bootstrap, where the apps have diverged from default styles and any custom styles needed to fill in the gaps.</p>
+<p class="lead">Admin app UIs are powered by <a href="https://getbootstrap.com/docs/3.4/">Bootstrap 3.4</a>, using <a href="https://github.com/twbs/bootstrap-sass/tree/v3.4.1">Bootstrap SASS</a> v3.4.1 (<a href="https://github.com/twbs/bootstrap-sass/blob/v3.4.1/assets/stylesheets/bootstrap/_mixins.scss">mixins</a>), but maintaining Bootstrap 2 button styles. This guide documents how we use Bootstrap, where the apps have diverged from default styles and any custom styles needed to fill in the gaps.</p>
 
 <h2 id="grid">Grid</h2>
-<p class="lead">Apps use the <a href="http://getbootstrap.com/css/#grid">default bootstrap</a> <strong>12 column scaleable responsive grid</strong>.</p>
+<p class="lead">Apps use the <a href="https://getbootstrap.com/docs/3.4/css/#grid">default bootstrap</a> <strong>12 column scaleable responsive grid</strong>.</p>
 <div class="row add-bottom-margin">
   <div class="grid-example col-md-2">col-md-2</div>
   <div class="grid-example col-md-4">col-md-4</div>
@@ -26,7 +26,7 @@
 <div class="row">
   <div class="col-md-6 lead">
     <p>
-      Based on the <a href="http://govuk-elements.herokuapp.com/form-elements/#form-toggle-content">GOV.UK elements pattern</a>, ticking a checkbox or selecting a radio element can toggle the display of further content or fields.
+      Based on the <a href="https://govuk-elements.herokuapp.com/form-elements/#form-toggle-content">GOV.UK elements pattern</a>, ticking a checkbox or selecting a radio element can toggle the display of further content or fields.
     </p>
     <pre class="add-top-margin">&lt;div class=&quot;checkbox&quot; data-module=&quot;toggle-checkbox&quot;&gt;
   &lt;label&gt;
@@ -73,7 +73,7 @@
 <h3 id="forms-input-widths">Input widths</h3>
 <div class="row">
   <div class="col-md-6 lead">
-    <p>Bootstrap 3 inputs always <a href="http://getbootstrap.com/css/#forms">extend to the size of their container</a>. The recommendation from Bootstrap is to wrap form elements with grid classes. Sometimes this isn’t suitable, for instance if a page isn’t using a grid.</p>
+    <p>Bootstrap 3 inputs always <a href="https://getbootstrap.com/docs/3.4/css/#forms">extend to the size of their container</a>. The recommendation from Bootstrap is to wrap form elements with grid classes. Sometimes this isn’t suitable, for instance if a page isn’t using a grid.</p>
     <p>The gem includes classes to restrict the width of inputs based on column sizes: <code>input-md-x</code> (1 — 11)</p>
   </div>
   <div class="col-md-6">
@@ -261,7 +261,7 @@
 <h3 id="tables-filterable-tables">Filterable tables</h3>
 <div class="row">
   <div class="col-md-6 lead">
-    <p>Using the <a href="https://github.com/alphagov/govuk_admin_template/blob/master/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js">filterable-table module</a> and the <a href="https://github.com/alphagov/govuk_admin_template/tree/master/app/views/govuk_admin_template/_table_filter.html.erb">table_filter partial</a> any table can be filtered. The module performs a simple match against the content of each row, if there’s no match the row is hidden.</p>
+    <p>Using the <a href="https://github.com/alphagov/govuk_admin_template/blob/main/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js">filterable-table module</a> and the <a href="https://github.com/alphagov/govuk_admin_template/blob/main/app/views/govuk_admin_template/_table_filter.html.erb">table_filter partial</a> any table can be filtered. The module performs a simple match against the content of each row, if there’s no match the row is hidden.</p>
     <p>If the class <code>js-open-on-submit</code> is added to a link within a row, then the first link visible with that class will be opened when the user hits <code>ENTER</code>.</p>
     <pre class="add-top-margin">&lt;table class="table table-bordered" data-module="filterable-table"&gt;
   &lt;thead&gt;
@@ -403,7 +403,7 @@
 <h2 id="nav-lists">Nav lists</h2>
 <div class="row">
   <p class="col-md-4 lead">
-    <a href="http://stackoverflow.com/questions/18281636/what-replaces-nav-lists-in-bootstrap-3">Bootstrap 3 removed</a> the <code>nav-list</code> classes and <a href="http://getbootstrap.com/2.3.2/components.html#navs">design pattern</a>. For backwards compatibility these styles have been put back, but it’s advised to avoid this pattern.
+    <a href="https://stackoverflow.com/questions/18281636/what-replaces-nav-lists-in-bootstrap-3">Bootstrap 3 removed</a> the <code>nav-list</code> classes and <a href="https://getbootstrap.com/2.3.2/components.html#navs">design pattern</a>. For backwards compatibility these styles have been put back, but it’s advised to avoid this pattern.
   </p>
   <div class="col-md-4">
     <div class="well sidebar-nav">

--- a/app/views/layouts/govuk_admin_template.html.erb
+++ b/app/views/layouts/govuk_admin_template.html.erb
@@ -101,7 +101,7 @@
       </main>
       <footer class="page-footer">
         <%= yield :footer_top %>
-        <a class="inherit" href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a>
+        <a class="inherit" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">&copy; Crown Copyright</a>
         <% if content_for?(:footer_version) %>
           <span class="pull-right">Version: <%= yield :footer_version %></span>
         <% end %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require File.expand_path("dummy/config/environment.rb", __dir__)
 require "capybara/rails"
 require "plek"
 
-# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+# See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.order = "random"
   config.include Capybara::DSL


### PR DESCRIPTION
This PR fixes up various bits of documentation in this repository.

It includes changes such as:
- fix broken links
- use https:// instead of http://
- update documentation to match recent changes
- change references to `master` branch to `main`

It also fixes a broken link to Crown Copyright in the footer of the admin template.

Trello: https://trello.com/c/kAh24TRP/303-bring-govukadmintemplate-up-to-speed