### PR TITLE
Fix Rails 6 compatibility: use `Date#to_formatted_s` instead of `Date#to_fs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,18 @@ name: Continuous integration
 on: [push, pull_request]
 
 jobs:
-  # This matrix job runs the test suite against multiple Ruby versions
+  # This matrix job runs the test suite against multiple Ruby and Rails versions
   test_matrix:
     strategy:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby: [2.7, '3.0', 3.1]
+        # Test against multiple Rails versions
+        gemfile: [rails_6, rails_7]
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ spec/dummy/tmp
 spec/dummy/public/assets
 node_modules
 Gemfile.lock
+gemfiles/*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 6.9.1
 
 * Fix broken Rails 6 compatibility: use `Date#to_formatted_s` instead of `Date#to_fs`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix broken Rails 6 compatibility: use `Date#to_formatted_s` instead of `Date#to_fs`
+
 # 6.9.0
 
 * Rails 7 compatibility: use `Time#to_fs` instead of deprecated use of `Time#to_s`

--- a/README.md
+++ b/README.md
@@ -274,6 +274,18 @@ yarn run jasmine:browser
 yarn run jasmine:ci
 ```
 
+### Testing against different Rails versions
+
+The CI pipeline is configured to test this gem against multiple versions of Rails.
+
+Each Rails version has a corresponding Gemfile located in the [gemfiles](gemfiles/) directory. And the CI pipeline defines a [matrix of Gemfiles](https://github.com/alphagov/govuk_admin_template/blob/8f53865fa3d33f741642783f9bfcaefc201c3751/.github/workflows/ci.yml#L13) to test against.
+
+It's also possible to run tests against multiple Rails versions locally.
+
+1. Run `export BUNDLE_GEMFILE="gemfiles/rails_X.gemfile"` where `X` is the version to test against.
+  This tells Bundler which Gemfile to use.
+2. Run `bundle install` and then `bundle exec rake` as usual.
+
 ## Publishing
 
 Version bumps will automatically update RubyGems.org.

--- a/app/views/govuk_admin_template/style_guide/index.html.erb
+++ b/app/views/govuk_admin_template/style_guide/index.html.erb
@@ -192,13 +192,13 @@
     <blockquote>
       <dl class="remove-bottom-margin">
         <dt class="add-label-margin"><code>:govuk_date</code></dt>
-        <dd><%= halloween.to_fs(:govuk_date) %><br />
-          <%= halloween.to_time.to_fs(:govuk_date) %></dd>
+        <dd><%= halloween.to_formatted_s(:govuk_date) %><br />
+          <%= halloween.to_time.to_formatted_s(:govuk_date) %></dd>
         <dt class="add-top-margin add-label-margin"><code>:govuk_date_short</code></dt>
-        <dd><%= halloween.to_fs(:govuk_date_short) %><br />
-          <%= halloween.to_time.to_fs(:govuk_date_short) %></dd>
+        <dd><%= halloween.to_formatted_s(:govuk_date_short) %><br />
+          <%= halloween.to_time.to_formatted_s(:govuk_date_short) %></dd>
         <dt class="add-top-margin add-label-margin"><code>:govuk_time</code></dt>
-        <dd><%= halloween.to_time.to_fs(:govuk_time) %></dd>
+        <dd><%= halloween.to_time.to_formatted_s(:govuk_time) %></dd>
       </dl>
     </blockquote>
   </section>

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 6"
+
+gemspec path: "../"

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7"
+
+gemspec path: "../"

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.9.0".freeze
+  VERSION = "6.9.1".freeze
 end


### PR DESCRIPTION
This PR fixes a Rails 6 compatibility issue inadvertently introduced by https://github.com/alphagov/govuk_admin_template/commit/664ddf6db78d6967dc8471f1faf3ff6bd593879f.

`Time#to_fs` exists in both Rails 6 and 7. But `Date#to_fs` is new in Rails 7.

So instead we use the method `#to_formatted_s` which exists in both Rails versions. This method is simply an alias of the `#to_fs` method.

## Tested against multiple Rails versions

This PR also configures the CI pipeline to test against both Rails 6 and Rails 7.

With this in place, it proves that this change is compatible in both supported Rails versions. And it'll protect us from inadvertently introducing other breaking changes in the future.