### PR TITLE
Remove Priority List example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.10.0
+
+* Remove Priority list from govspeak help example
+
 # 6.9.2
 
 * Fix providing gem internal Rake tasks to applications embedding this gem as an engine.

--- a/app/views/govuk_admin_template/_govspeak_help.html.erb
+++ b/app/views/govuk_admin_template/_govspeak_help.html.erb
@@ -81,23 +81,6 @@
   </div>
 
   <h3>
-    <a data-toggle="collapse" href="#govspeak-priority-list">
-      Priority list
-    </a>
-  </h3>
-  <div class="collapse" id="govspeak-priority-list">
-    <p>
-      You can create a list which shows only the first n items (including attachments),
-      with a link to open the others, eg to show the first item:
-    </p>
-
-    <pre>$PriorityList:1
-  * item 1
-  * item 2
-  * item 3</pre>
-  </div>
-
-  <h3>
     <a data-toggle="collapse" href="#govspeak-legislative-list">
       Legislative list
     </a>

--- a/lib/govuk_admin_template/version.rb
+++ b/lib/govuk_admin_template/version.rb
@@ -1,3 +1,3 @@
 module GovukAdminTemplate
-  VERSION = "6.9.2".freeze
+  VERSION = "6.10.0".freeze
 end


### PR DESCRIPTION
## What
Remove Priority list from govspeak help example

## Why
The Priority List example is not required, this functionality is to be removed from govspeak and govuk-publishing-components.

## Visual Changes
I tested in the changes locally using the 'manuals publisher' app, the screenshots below show the changes before and after.

| Before | After |
| - | - |
| <img width="385" alt="before" src="https://user-images.githubusercontent.com/28779939/180733600-89a49d9d-ea67-48e0-96d9-1dca993f9f4e.png"> | <img width="294" alt="after" src="https://user-images.githubusercontent.com/28779939/180733654-4fd5ce03-15f8-45e7-ab87-03f69d668f65.png"> |

---

Trello: https://trello.com/c/nezjGrzF/1388-investigate-and-potentially-fix-primary-links-module