### PR TITLE
Fix tests where ENV.fetch receiving calls which aren't stubbed

### DIFF
--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -106,6 +106,7 @@ describe "Layout" do
   describe "in production" do
     before do
       allow(Rails.env).to receive(:production?).and_return(true)
+      allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with("GOVUK_APP_DOMAIN").and_return("root.gov.uk")
     end
 


### PR DESCRIPTION
## Description

Tests are currently broken on main.

ENV.fetch  is being called multiple times, but has only been stubbed once. I've updated it to call original, as they don't need to be stubbed.