### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', 3.1]
+        ruby: [2.7, '3.0', 3.1, 3.2]
         # Test against multiple Rails versions
         gemfile: [rails_6, rails_7]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ruby 3.2 was released on December 25th 2022