### PR TITLE
Bump JQuery Rails gem, and also use JQuery 3.

### DIFF
--- a/app/assets/javascripts/govuk-admin-template.js
+++ b/app/assets/javascripts/govuk-admin-template.js
@@ -1,5 +1,4 @@
-//= require jquery
-//= require jquery_ujs
+//= require jquery3
 //= require bootstrap
 //= require govuk-admin-template/govuk-admin
 //= require_tree ./govuk-admin-template/modules

--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 3.0"
 
   gem.add_dependency "bootstrap-sass", "~> 3.4"
-  gem.add_dependency "jquery-rails", "~> 4.3"
+  gem.add_dependency "jquery-rails", "~> 4.6"
   gem.add_dependency "plek", ">= 2.1"
   gem.add_dependency "rails", ">= 6"
 


### PR DESCRIPTION
JQuery Rails gem homepage states that if we're using Rails 5+ then jquery_ujs isn't required and hence has been removed

https://trello.com/c/O38OsUHn/1284-update-jquery-version-in-govukadmintemplate