### PR TITLE
Update govuk_admin_template.gemspec

### DIFF
--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary       = gem.description
   gem.homepage      = "https://github.com/alphagov/govuk_admin_template"
 
-  gem.files         = Dir["{app,config,lib}/**/*"] + Dir["*.md"] + ["LICENCE.txt"]
+  gem.files         = Dir["{app,config,lib}/**/*"] + Dir["*.md"] + %w[LICENCE]
   gem.require_paths = %w[lib]
 
   gem.required_ruby_version = ">= 3.1"


### PR DESCRIPTION
LICENCE.txt was renamed to LICENCE but this reference in the gemspec had not been updated, which caused an [error](https://github.com/alphagov/govuk_admin_template/actions/runs/9363987558/job/25776181390) when trying to publish the gem.