### PR TITLE
Use GOVUK_ENVIRONMENT env var to set styling

### DIFF
--- a/govuk_admin_template.gemspec
+++ b/govuk_admin_template.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rails", ">= 6"
 
   gem.add_development_dependency "capybara", "~> 3"
+  gem.add_development_dependency "climate_control", "~> 1"
   gem.add_development_dependency "rspec-rails", "~> 5"
   gem.add_development_dependency "rubocop-govuk", "4.17.1"
   gem.add_development_dependency "sassc-rails", "~> 2"

--- a/lib/govuk_admin_template.rb
+++ b/lib/govuk_admin_template.rb
@@ -8,18 +8,10 @@ module GovukAdminTemplate
   mattr_accessor :environment_style, :environment_label
 
   def self.environment_style
-    @@environment_style || default_environment_style
+    @environment_style ||= ENV["GOVUK_ENVIRONMENT"] == "production" ? "production" : "preview"
   end
 
   def self.environment_label
-    @@environment_label || environment_style.try(:titleize)
-  end
-
-  # In development we can't consistently set an environment
-  # variable, so use a default based on Rails.env
-  def self.default_environment_style
-    if Rails.env.development?
-      "development"
-    end
+    @environment_label ||= ENV.fetch("GOVUK_ENVIRONMENT", "development").titleize
   end
 end

--- a/spec/layout/layout_spec.rb
+++ b/spec/layout/layout_spec.rb
@@ -1,7 +1,14 @@
+require "climate_control"
 require "spec_helper"
 
 describe "Layout" do
   subject(:body) { page.body }
+
+  before do
+    # Reset the class instance variables before each test
+    GovukAdminTemplate.instance_variable_set(:@environment_style, nil)
+    GovukAdminTemplate.instance_variable_set(:@environment_label, nil)
+  end
 
   it "yields the specified content" do
     visit "/"
@@ -16,31 +23,37 @@ describe "Layout" do
     expect(page).to have_title "page_title"
   end
 
-  context "when no environment set" do
-    it "defaults to not showing any environment details" do
-      GovukAdminTemplate.environment_style = nil
-      visit "/"
-      expect(page).not_to have_selector(".environment-label")
-      expect(page).not_to have_selector(".environment-message")
-      expect(page.body).to match(/favicon-.*.png/)
+  context "when GOVUK_ENVIRONMENT not set" do
+    it "defaults to development environment details" do
+      ClimateControl.modify GOVUK_ENVIRONMENT: nil do
+        visit "/"
+        expect(page).to have_selector(".environment-label", text: "Development")
+        expect(page).to have_selector(".environment-preview")
+        expect(page.body).to match(/favicon-preview.*.png/)
+      end
     end
   end
 
-  context "when in a development environment" do
+  context "when GOVUK_ENVIRONMENT is set to production" do
     it "includes details about the current environment" do
-      GovukAdminTemplate.environment_style = "development"
-      visit "/"
-      expect(page).to have_selector(".environment-label", text: "Development")
-      expect(page).to have_selector(".environment-development")
-      expect(page.body).to match(/favicon-development-.*.png/)
+      ClimateControl.modify GOVUK_ENVIRONMENT: "production" do
+        visit "/"
+        expect(page).to have_selector(".environment-label", text: "Production")
+        expect(page).to have_selector(".environment-production")
+        expect(page.body).to match(/favicon-production-.*.png/)
+      end
     end
   end
 
-  context "when in a test environment" do
+  context "when GOVUK_ENVIRONMENT is set to integration" do
     it "includes details about the current environment" do
-      GovukAdminTemplate.environment_style = "test"
-      visit "/"
-      expect(page.body).to match(/favicon-test-.*.png/)
+      ClimateControl.modify GOVUK_ENVIRONMENT: "integration" do
+        visit "/"
+        p body
+        expect(page).to have_selector(".environment-label", text: "Integration")
+        expect(page).to have_selector(".environment-preview")
+        expect(page.body).to match(/favicon-preview-.*.png/)
+      end
     end
   end
 


### PR DESCRIPTION
There are a set number of apps that use this gem. They all configure the environment_style and environment_label with the exactly same configuration. This moves the repeated configuration into the this gem as standard.

e.g. https://github.com/alphagov/support/blob/main/config/initializers/govuk_admin_template.rb

```
GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT", "development").titleize
GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT"] == "production" ? "production" : "preview"
```

This will have no effect on the behaviour of the dependent apps, and allow us to remove repeated config.

The only apps that use this gem are:

- Publisher
- Maslow
- Support
- Specialist publisher
- Short url manager
- Transition
- Service manual publisher
- Contacts admin
- Search admin
- Content tagger

And all have the same configuration.