### PR TITLE
Disable all Dependabot updates apart from security ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,16 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0


### PR DESCRIPTION
As done in https://github.com/alphagov/content-publisher/pull/3287 and https://github.com/alphagov/maslow/pull/1293, we want to disable Dependabot PRs for this deprecated repo.