### PR TITLE
Remove Contacts Admin from list of apps using gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This gem provides (via a Rails engine):
 * Google Analytics tracking code (Universal Analytics), using the "GOV.UK apps" profile
 
 [Apps using this gem](https://github.com/search?q=govuk_admin_template+user%3Aalphagov+path%3AGemfile.lock) include:
-* [Contacts admin](https://github.com/alphagov/contacts-admin)
 * [Content tagger](https://github.com/alphagov/content-tagger)
 * [Maslow](https://github.com/alphagov/maslow)
 * [Publisher](https://github.com/alphagov/publisher)


### PR DESCRIPTION
Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin